### PR TITLE
[Bug/#27] 로컬 스토리지 메서드 에러 핸들링 및 버그 해결

### DIFF
--- a/src/utils/storage/index.ts
+++ b/src/utils/storage/index.ts
@@ -8,37 +8,58 @@ type StorageType = {
 };
 
 export class LocalStorage implements StorageType {
-  private serialize = <T>(value: T) => {
-    return JSON.stringify(value);
+  private serialize = <T>(value: T): string | null => {
+    try {
+      return JSON.stringify(value);
+    } catch (error) {
+      console.error(error);
+      return null;
+    }
   };
 
-  private deserialize = (value: string) => {
+  private deserialize = (value: string): string | null => {
     try {
       return JSON.parse(value);
-    } catch (e) {
-      return "";
+    } catch (error) {
+      console.error(error);
+      return null;
     }
   };
-  get(key: string) {
+
+  get(key: string): string | null {
     try {
       return this.deserialize(localStorage.getItem(key) || "");
-    } catch (e) {
-      return "";
+    } catch (error) {
+      console.error(error);
+      return null;
     }
   }
 
-  set(key: string, value: string) {
-    localStorage.setItem(key, this.serialize(value));
+  set(key: string, value: string): void {
+    try {
+      localStorage.setItem(key, this.serialize(value) as string);
+    } catch (error) {
+      console.error(error);
+    }
   }
 
-  remove(key: string) {
-    localStorage.removeItem(key);
+  remove(key: string): void {
+    try {
+      localStorage.removeItem(key);
+    } catch (error) {
+      console.error(error);
+    }
   }
 
-  clearAll() {
-    localStorage.clear();
+  clearAll(): void {
+    try {
+      localStorage.clear();
+    } catch (error) {
+      console.error(error);
+    }
   }
 }
 
 const lStorage = new LocalStorage();
+
 export default lStorage;


### PR DESCRIPTION
## Describe your changes
<!-- 스크린샷 및 작업내용을 적어주세요 -->
로컬 스토리지 메서드 상 잘못된 로직이 있어 수정했습니다.

기존에는 아래와 같이 에러 핸들링이 제대로 되지 않았습니다.
에러가 난 경우에도 빈 문자열을 반환하도록 해서 에러인 경우와 진짜 빈 문자열인 경우를 구분하지 못했습니다.
```ts
  private deserialize = (value: string) => {
    try {
      return JSON.parse(value);
    } catch (e) {
      return "";
    }
  };
```

개선한 코드는 아래와 같습니다.
에러 발생 시 콘솔에 에러를 띄워주고 빈 문자열과 명확하게 구분하기 위해서 널을 반환하도록 로직을 변경했습니다.
```ts
private deserialize = (value: string): string | null => {
    try {
      return JSON.parse(value);
    } catch (error) {
      console.error(error);
      return null;
    }
  };
```

또한 각 메서드의 반환 타입을 명확히 지정해주었습니다.

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->