### PR TITLE
[Bug/#39]: 버셀 배포 사이트 새로 고침 시 404 뜨는 문제 해결

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -1,0 +1,5 @@
+{
+  "rewrites": [
+    {"source": "/(.*)", "destination": "/"}
+  ]
+}


### PR DESCRIPTION
## Describe your changes
<!-- 스크린샷 및 작업내용을 적어주세요 -->
버셀 배포 사이트 새로 고침 시 404 뜨는 문제 해결합니다.
<img width="439" alt="image" src="https://github.com/GDSC-Hongik/gdsc-admin/assets/81316050/2c72c4fd-6b08-4882-82b2-c58381d13875">


vercel.json 파일에 아래 코드 추가해주었습니다.
<img width="798" alt="image" src="https://github.com/GDSC-Hongik/gdsc-admin/assets/81316050/6894d438-3c3e-4e46-bdbf-8003c6a61665">


## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->