### PR TITLE
[Bug/#45] 멤버 승인 후 승인 리스트가 업데이트되지 않는 문제 해결

### DIFF
--- a/src/hooks/mutations/useGrantMemberMutation.ts
+++ b/src/hooks/mutations/useGrantMemberMutation.ts
@@ -11,7 +11,7 @@ export default function useGrantMemberMutation() {
     mutationFn: pendingMemberApi.grantPendingMember,
     onSuccess: data => {
       queryClient.invalidateQueries({
-        queryKey: [QueryKey.pendingMemberList],
+        queryKey: [QueryKey.grantableMemberList],
       });
       data.grantedMembers?.map(member => {
         toast.success(`${formatNullableValue(member)}님의 승인이 완료되었습니다.`);


### PR DESCRIPTION
## Describe your changes
<!-- 스크린샷 및 작업내용을 적어주세요 -->
멤버 승인 후 승인 리스트가 업데이트되지 않는 문제를 해결했습니다.
invalidateQueries 속성을 잘못 적용하여 이 부분을 수정했습니다.

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->