### PR TITLE
[Bug/#63] 멤버 정보 수정 시 모든 필드가 다 작성되었는지 확인하는 validation 삭제

### DIFF
--- a/src/components/common/InfoModal/EditInfoModal/index.tsx
+++ b/src/components/common/InfoModal/EditInfoModal/index.tsx
@@ -61,29 +61,19 @@ export default function EditInfoModal({
   }, [selectedMemberInfo, isModalVisible, setDepartmentSearchText]);
 
   useEffect(() => {
-    const isNameValid = memberInfo.name.trim() !== "";
     const isStudentIdValid =
-      memberInfo.studentId.trim() !== "" &&
-      RegExp(memberInfoValidation.studentId.regExp).test(memberInfo.studentId);
+      !memberInfo.studentId || RegExp(memberInfoValidation.studentId.regExp).test(memberInfo.studentId);
     const isPhoneValid =
-      memberInfo.phone.trim() !== "" &&
-      RegExp(memberInfoValidation.phone.regExp).test(formatPhoneNumber(memberInfo.phone));
-    const isDepartmentValid = memberInfo.department.code?.trim() !== "";
+      !memberInfo.phone || RegExp(memberInfoValidation.phone.regExp).test(formatPhoneNumber(memberInfo.phone));
     const isEmailValid =
-      memberInfo.email.trim() !== "" &&
-      RegExp(memberInfoValidation.email.regExp).test(memberInfo.email);
-    const isDiscordUsernameValid = memberInfo.discordUsername.trim() !== "";
+      !memberInfo.email || RegExp(memberInfoValidation.email.regExp).test(memberInfo.email);
     const isNicknameValid =
-      memberInfo.nickname.trim() !== "" &&
-      RegExp(memberInfoValidation.nickname.regExp).test(memberInfo.nickname);
+      !memberInfo.nickname || RegExp(memberInfoValidation.nickname.regExp).test(memberInfo.nickname);
 
     const isSaveButtonDisabled = !(
-      isNameValid &&
       isStudentIdValid &&
       isPhoneValid &&
-      isDepartmentValid &&
       isEmailValid &&
-      isDiscordUsernameValid &&
       isNicknameValid
     );
 


### PR DESCRIPTION
## Describe your changes
현재 멤버 정보 수정 시 모든 필드가 다 작성되지 않았다면 저장하기 버튼이 활성화되지 않습니다.
하지만, 아직 디스코드 인증을 하지 않은 사용자는 디스코드 닉네임과 디스코드 사용자명이 null 값이기 때문에 이 validation 적용으로 인해 학과 정보 등을 수정하지 못합니다.
따라서 이 validation을 삭제합니다.

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->