### PR TITLE
[Bug/#68] 멤버 정보 수정 시 빈 필드는 빈 문자열 대신 null 입력하도록 수정

### DIFF
--- a/src/apis/allMemberApi.ts
+++ b/src/apis/allMemberApi.ts
@@ -41,8 +41,8 @@ export const allMemberApi = {
       phone: string;
       department: string;
       email: string;
-      discordUsername: string;
-      nickname: string;
+      discordUsername: string | null;
+      nickname: string | null;
     },
   ) => {
     const response = await apiClient.put(`admin/members/${memberId}`, body);

--- a/src/components/common/InfoModal/EditInfoModal/ThirdRow.tsx
+++ b/src/components/common/InfoModal/EditInfoModal/ThirdRow.tsx
@@ -31,8 +31,8 @@ export default function ThirdRow({
           name="nickname"
           value={nickname}
           onChange={handleChangeMemberInfo}
-          error={nickname?.length > 0 && !RegExp(memberInfoValidation.nickname.regExp).test(nickname)}
-          helperText={nickname?.length > 0 && !RegExp(memberInfoValidation.nickname.regExp).test(nickname) ? memberInfoValidation.nickname.errorText : ''}
+          error={nickname ? !RegExp(memberInfoValidation.nickname.regExp).test(nickname) : undefined}
+          helperText={nickname && !RegExp(memberInfoValidation.nickname.regExp).test(nickname) ? memberInfoValidation.nickname.errorText : ''}
         />
       </ColContainer>
     </RowContainer>

--- a/src/components/common/InfoModal/EditInfoModal/ThirdRow.tsx
+++ b/src/components/common/InfoModal/EditInfoModal/ThirdRow.tsx
@@ -29,7 +29,7 @@ export default function ThirdRow({
         <StyledTextField
           size="small"
           name="nickname"
-          value={nickname || null}
+          value={nickname?.length ? nickname : null}
           onChange={handleChangeMemberInfo}
           error={nickname ? !RegExp(memberInfoValidation.nickname.regExp).test(nickname) : undefined}
           helperText={nickname && !RegExp(memberInfoValidation.nickname.regExp).test(nickname) ? memberInfoValidation.nickname.errorText : ''}

--- a/src/components/common/InfoModal/EditInfoModal/ThirdRow.tsx
+++ b/src/components/common/InfoModal/EditInfoModal/ThirdRow.tsx
@@ -29,7 +29,7 @@ export default function ThirdRow({
         <StyledTextField
           size="small"
           name="nickname"
-          value={nickname?.length ? nickname : null}
+          value={nickname}
           onChange={handleChangeMemberInfo}
           error={nickname ? !RegExp(memberInfoValidation.nickname.regExp).test(nickname) : undefined}
           helperText={nickname && !RegExp(memberInfoValidation.nickname.regExp).test(nickname) ? memberInfoValidation.nickname.errorText : ''}

--- a/src/components/common/InfoModal/EditInfoModal/ThirdRow.tsx
+++ b/src/components/common/InfoModal/EditInfoModal/ThirdRow.tsx
@@ -29,7 +29,7 @@ export default function ThirdRow({
         <StyledTextField
           size="small"
           name="nickname"
-          value={nickname}
+          value={nickname || null}
           onChange={handleChangeMemberInfo}
           error={nickname ? !RegExp(memberInfoValidation.nickname.regExp).test(nickname) : undefined}
           helperText={nickname && !RegExp(memberInfoValidation.nickname.regExp).test(nickname) ? memberInfoValidation.nickname.errorText : ''}

--- a/src/components/common/InfoModal/EditInfoModal/index.tsx
+++ b/src/components/common/InfoModal/EditInfoModal/index.tsx
@@ -54,8 +54,8 @@ export default function EditInfoModal({
         name: "",
       },
       email: selectedMemberInfo.email ?? "",
-      discordUsername: selectedMemberInfo.discordUsername ?? "",
-      nickname: selectedMemberInfo.nickname ?? "",
+      discordUsername: selectedMemberInfo.discordUsername ?? null,
+      nickname: selectedMemberInfo.nickname ?? null,
     });
     setDepartmentSearchText(selectedMemberInfo.department.name ?? "");
   }, [selectedMemberInfo, isModalVisible, setDepartmentSearchText]);

--- a/src/components/common/InfoModal/EditInfoModal/index.tsx
+++ b/src/components/common/InfoModal/EditInfoModal/index.tsx
@@ -38,8 +38,8 @@ export default function EditInfoModal({
       name: "",
     },
     email: "",
-    discordUsername: "",
-    nickname: "",
+    discordUsername: null,
+    nickname: null,
   });
   const [isButtonDisabled, setIsButtonDisabled] = useState(true);
 

--- a/src/components/common/InfoModal/EditInfoModal/index.tsx
+++ b/src/components/common/InfoModal/EditInfoModal/index.tsx
@@ -45,19 +45,19 @@ export default function EditInfoModal({
 
   useEffect(() => {
     setMemberInfo({
-      memberId: selectedMemberInfo.memberId ?? 0,
-      name: selectedMemberInfo.name ?? "",
-      studentId: selectedMemberInfo.studentId ?? "",
-      phone: selectedMemberInfo.phone ?? "",
-      department: selectedMemberInfo.department ?? {
+      memberId: selectedMemberInfo.memberId || 0,
+      name: selectedMemberInfo.name || "",
+      studentId: selectedMemberInfo.studentId || "",
+      phone: selectedMemberInfo.phone || "",
+      department: selectedMemberInfo.department || {
         code: "",
         name: "",
       },
-      email: selectedMemberInfo.email ?? "",
-      discordUsername: selectedMemberInfo.discordUsername ?? null,
-      nickname: selectedMemberInfo.nickname ?? null,
+      email: selectedMemberInfo.email || "",
+      discordUsername: selectedMemberInfo.discordUsername || null,
+      nickname: selectedMemberInfo.nickname || null,
     });
-    setDepartmentSearchText(selectedMemberInfo.department.name ?? "");
+    setDepartmentSearchText(selectedMemberInfo.department.name || "");
   }, [selectedMemberInfo, isModalVisible, setDepartmentSearchText]);
 
   useEffect(() => {

--- a/src/components/common/InfoModal/EditInfoModal/index.tsx
+++ b/src/components/common/InfoModal/EditInfoModal/index.tsx
@@ -110,8 +110,8 @@ export default function EditInfoModal({
     phone: formatPhoneNumber(phone),
     department: department.code,
     email: email,
-    discordUsername: discordUsername,
-    nickname: nickname,
+    discordUsername: discordUsername || null,
+    nickname: nickname || null,
   }, () => setIsModalVisible(false));
 
   return (

--- a/src/hooks/mutations/useEditMemberInfoMutation.ts
+++ b/src/hooks/mutations/useEditMemberInfoMutation.ts
@@ -23,7 +23,7 @@ export default function useEditMemberInfoMutation(
     onSuccess: async () => {
       Promise.all([
         queryClient.invalidateQueries({
-          queryKey: [QueryKey.allMemberList, QueryKey.grantableMemberList],
+          queryKey: [QueryKey.allMemberList],
         }),
         queryClient.invalidateQueries({
           queryKey: [QueryKey.allMemberList],

--- a/src/hooks/mutations/useEditMemberInfoMutation.ts
+++ b/src/hooks/mutations/useEditMemberInfoMutation.ts
@@ -21,8 +21,11 @@ export default function useEditMemberInfoMutation(
   return useMutation({
     mutationFn: () => allMemberApi.editMemberInfo(memberId, body),
     onSuccess: async () => {
-      await queryClient.refetchQueries({
-        queryKey: [QueryKey.allMemberList, QueryKey.grantableMemberList]
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.allMemberList, QueryKey.grantableMemberList],
+      });
+      queryClient.invalidateQueries({
+        queryKey: [QueryKey.allMemberList],
       });
       toast.success("수정 완료되었습니다.")
       onSuccessCallback();

--- a/src/hooks/mutations/useEditMemberInfoMutation.ts
+++ b/src/hooks/mutations/useEditMemberInfoMutation.ts
@@ -20,8 +20,10 @@ export default function useEditMemberInfoMutation(
 
   return useMutation({
     mutationFn: () => allMemberApi.editMemberInfo(memberId, body),
-    onSuccess: () => {
-      queryClient.invalidateQueries({ queryKey: [QueryKey.allMemberList, QueryKey.grantableMemberList] });
+    onSuccess: async () => {
+      await queryClient.refetchQueries({
+        queryKey: [QueryKey.allMemberList, QueryKey.grantableMemberList]
+      });
       toast.success("수정 완료되었습니다.")
       onSuccessCallback();
     },

--- a/src/hooks/mutations/useEditMemberInfoMutation.ts
+++ b/src/hooks/mutations/useEditMemberInfoMutation.ts
@@ -26,7 +26,7 @@ export default function useEditMemberInfoMutation(
           queryKey: [QueryKey.allMemberList],
         }),
         queryClient.invalidateQueries({
-          queryKey: [QueryKey.allMemberList],
+          queryKey: [QueryKey.grantableMemberList],
         })
       ])
       toast.success("수정 완료되었습니다.")

--- a/src/hooks/mutations/useEditMemberInfoMutation.ts
+++ b/src/hooks/mutations/useEditMemberInfoMutation.ts
@@ -11,8 +11,8 @@ export default function useEditMemberInfoMutation(
     phone: string;
     department: string;
     email: string;
-    discordUsername: string;
-    nickname: string;
+    discordUsername: string | null;
+    nickname: string | null;
   },
   onSuccessCallback: () => void,
 ) {

--- a/src/hooks/mutations/useEditMemberInfoMutation.ts
+++ b/src/hooks/mutations/useEditMemberInfoMutation.ts
@@ -22,8 +22,8 @@ export default function useEditMemberInfoMutation(
     mutationFn: () => allMemberApi.editMemberInfo(memberId, body),
     onSuccess: () => {
       queryClient.invalidateQueries({ queryKey: [QueryKey.allMemberList, QueryKey.grantableMemberList] });
-      onSuccessCallback();
       toast.success("수정 완료되었습니다.")
+      onSuccessCallback();
     },
     onError: (error: any) => {
       toast.error(error.response.data.errorMessage)

--- a/src/hooks/mutations/useEditMemberInfoMutation.ts
+++ b/src/hooks/mutations/useEditMemberInfoMutation.ts
@@ -28,12 +28,12 @@ export default function useEditMemberInfoMutation(
         queryClient.invalidateQueries({
           queryKey: [QueryKey.grantableMemberList],
         })
-      ])
-      toast.success("수정 완료되었습니다.")
+      ]);
+      toast.success("수정 완료되었습니다.");
       onSuccessCallback();
     },
     onError: (error: any) => {
-      toast.error(error.response.data.errorMessage)
+      toast.error(error.response.data.errorMessage);
     },
   });
 }

--- a/src/hooks/mutations/useEditMemberInfoMutation.ts
+++ b/src/hooks/mutations/useEditMemberInfoMutation.ts
@@ -21,12 +21,14 @@ export default function useEditMemberInfoMutation(
   return useMutation({
     mutationFn: () => allMemberApi.editMemberInfo(memberId, body),
     onSuccess: async () => {
-      queryClient.invalidateQueries({
-        queryKey: [QueryKey.allMemberList, QueryKey.grantableMemberList],
-      });
-      queryClient.invalidateQueries({
-        queryKey: [QueryKey.allMemberList],
-      });
+      Promise.all([
+        queryClient.invalidateQueries({
+          queryKey: [QueryKey.allMemberList, QueryKey.grantableMemberList],
+        }),
+        queryClient.invalidateQueries({
+          queryKey: [QueryKey.allMemberList],
+        })
+      ])
       toast.success("수정 완료되었습니다.")
       onSuccessCallback();
     },

--- a/src/types/entities/member.ts
+++ b/src/types/entities/member.ts
@@ -10,8 +10,8 @@ export type AllMemberInfoType = {
     name: string;
   };
   email: string;
-  discordUsername: string;
-  nickname: string;
+  discordUsername: string | null;
+  nickname: string | null;
 };
 
 export type AllMemberInfoStateType = AllMemberInfoType;


### PR DESCRIPTION
## Describe your changes
<!-- 스크린샷 및 작업내용을 적어주세요 -->
멤버 정보 수정 시 빈 필드는 빈 문자열 대신 null 입력하도록 수정했고,
멤버 정보 수정 후 invalidateQueries가 작동 안 하는 문제가 있어서 수정했습니다.

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->