### PR TITLE
[Refactor/#82] 전역 상태 로직 selector 사용하도록 변경

### DIFF
--- a/src/components/common/Table/AllMemberInfoTable/index.tsx
+++ b/src/components/common/Table/AllMemberInfoTable/index.tsx
@@ -1,19 +1,17 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
 import { Grid, TablePagination } from "@mui/material";
-import { useStore } from "zustand";
 import AllMemberInfoTableBody from "./AllMemberInfoTableBody";
 import AllMemberInfoTableHeader from "./AllMemberInfoTableHeader";
 import useGetAllMemberListQuery from "@/hooks/queries/useGetAllMemberListQuery";
-import { allMembersStore } from "@/store/allMembers";
+import { useAllMembersStore } from "@/store/allMembers";
 
 export default function AllMemberInfoTable() {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
-  const {
-    searchInfo: { variant: searchVariant, text: searchText },
-  } = useStore(allMembersStore);
+  const searchVariant = useAllMembersStore(state => state.searchInfo.variant);
+  const searchText = useAllMembersStore(state => state.searchInfo.text);
 
   const { allMemberList = [], totalElements = 0 } = useGetAllMemberListQuery(
     page,

--- a/src/components/common/Table/GrantableMemberInfoTable/index.tsx
+++ b/src/components/common/Table/GrantableMemberInfoTable/index.tsx
@@ -1,19 +1,17 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
 import { Grid, TablePagination } from "@mui/material";
-import { useStore } from "zustand";
 import GrantableMemberInfoTableBody from "./GrantableMemberInfoTableBody";
 import GrantableMemberInfoTableHeader from "./GrantableMemberInfoTableHeader";
 import useGetGrantableMemberListQuery from "@/hooks/queries/useGetGrantableMemberListQuery";
-import { grantableMembersStore } from "@/store/grantableMembers";
+import { useGrantableMembersStore } from "@/store/grantableMembers";
 
 export default function GrantableMemberInfoTable() {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
-  const {
-    searchInfo: { text: grantableMemberSearchText, variant: grantableMemberSearchVariant },
-  } = useStore(grantableMembersStore);
+  const grantableMemberSearchText = useGrantableMembersStore(state => state.searchInfo.text);
+  const grantableMemberSearchVariant = useGrantableMembersStore(state => state.searchInfo.variant);
 
   const { grantableMemberList = [], totalElements = 0 } = useGetGrantableMemberListQuery(
     page,

--- a/src/components/common/Table/GrantedMemberInfoTable/index.tsx
+++ b/src/components/common/Table/GrantedMemberInfoTable/index.tsx
@@ -1,19 +1,17 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
 import { Grid, TablePagination } from "@mui/material";
-import { useStore } from "zustand";
 import GrantedMemberInfoTableBody from "./GrantedMemberInfoTableBody";
 import GrantedMemberInfoTableHeader from "./GrantedMemberInfoTableHeader";
 import useGetGrantedMemberListQuery from "@/hooks/queries/useGetGrantedMemberListQuery";
-import { grantedMembersStore } from "@/store/grantedMembers";
+import { useGrantedMembersStore } from "@/store/grantedMembers";
 
 export default function GrantedMemberInfoTable() {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
-  const {
-    searchInfo: { variant: grantedMemberSearchVariant, text: grantedMemberSearchText },
-  } = useStore(grantedMembersStore);
+  const grantedMemberSearchText = useGrantedMembersStore(state => state.searchInfo.text);
+  const grantedMemberSearchVariant = useGrantedMembersStore(state => state.searchInfo.variant);
 
   const { grantedMemberList = [], totalElements = 0 } = useGetGrantedMemberListQuery(
     page,

--- a/src/components/common/Table/PaymentStatusInfoTable/index.tsx
+++ b/src/components/common/Table/PaymentStatusInfoTable/index.tsx
@@ -1,19 +1,21 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
 import { Grid, TablePagination } from "@mui/material";
-import { useStore } from "zustand";
 import PaymentStatusInfoTableBody from "./PaymentStatusInfoTableBody";
 import PaymentStatusInfoTableHeader from "./PaymentStatusInfoTableHeader";
 import useGetPaymentStatusMemberListQuery from "@/hooks/queries/useGetPaymentStatusMemberListQuery";
-import { paymentStatusMembersStore } from "@/store/paymentStatusMembers";
+import { usePaymentStatusMembersStore } from "@/store/paymentStatusMembers";
 
 export default function PaymentStatusInfoTable() {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
-  const {
-    searchInfo: { text: paymentStatusMemberSearchText, variant: paymentStatusMemberSearchVariant },
-  } = useStore(paymentStatusMembersStore);
+  const paymentStatusMemberSearchText = usePaymentStatusMembersStore(
+    state => state.searchInfo.text,
+  );
+  const paymentStatusMemberSearchVariant = usePaymentStatusMembersStore(
+    state => state.searchInfo.variant,
+  );
 
   const { paymentStatusMemberList = [], totalElements = 0 } = useGetPaymentStatusMemberListQuery(
     page,

--- a/src/components/common/Table/PendingMemberInfoTable/index.tsx
+++ b/src/components/common/Table/PendingMemberInfoTable/index.tsx
@@ -1,19 +1,17 @@
 import { useState } from "react";
 import styled from "@emotion/styled";
 import { Grid, TablePagination } from "@mui/material";
-import { useStore } from "zustand";
 import PendingMemberInfoTableBody from "./PendingMemberInfoTableBody";
 import PendingMemberInfoTableHeader from "./PendingMemberInfoTableHeader";
 import useGetPendingMemberListQuery from "@/hooks/queries/useGetPendingMemberListQuery";
-import { pendingMembersStore } from "@/store/pendingMembers";
+import { usePendingMembersStore } from "@/store/pendingMembers";
 
 export default function PendingMemberInfoTable() {
   const [page, setPage] = useState(0);
   const [rowsPerPage, setRowsPerPage] = useState(10);
 
-  const {
-    searchInfo: { text: pendingMemberSearchText, variant: pendingMemberSearchVariant },
-  } = useStore(pendingMembersStore);
+  const pendingMemberSearchText = usePendingMembersStore(state => state.searchInfo.text);
+  const pendingMemberSearchVariant = usePendingMembersStore(state => state.searchInfo.variant);
 
   const { pendingMemberList = [], totalElements = 0 } = useGetPendingMemberListQuery(
     page,

--- a/src/hooks/useGetSearchTextSetters.ts
+++ b/src/hooks/useGetSearchTextSetters.ts
@@ -1,24 +1,24 @@
-import { UseBoundStore, StoreApi, useStore } from "zustand";
-import { allMembersStore } from "@/store/allMembers";
-import { grantableMembersStore } from "@/store/grantableMembers";
-import { grantedMembersStore } from "@/store/grantedMembers";
-import { paymentStatusMembersStore } from "@/store/paymentStatusMembers";
-import { pendingMembersStore } from "@/store/pendingMembers";
+import { UseBoundStore, StoreApi } from "zustand";
+import { useAllMembersStore } from "@/store/allMembers";
+import { useGrantableMembersStore } from "@/store/grantableMembers";
+import { useGrantedMembersStore } from "@/store/grantedMembers";
+import { usePaymentStatusMembersStore } from "@/store/paymentStatusMembers";
+import { usePendingMembersStore } from "@/store/pendingMembers";
 import { MemberStoreType } from "@/types/entities/store";
 
 export default function useGetSearchTextSetters() {
-  const useGetSearchTextSetter = (store: UseBoundStore<StoreApi<MemberStoreType>>) => {
-    const { setSearchText } = useStore(store);
+  const useGetSearchTextSetter = (useMembersStore: UseBoundStore<StoreApi<MemberStoreType>>) => {
+    const setSearchText = useMembersStore(state => state.setSearchText);
 
     return setSearchText;
   };
 
   const setSearchTextFunctions = {
-    allMember: useGetSearchTextSetter(allMembersStore),
-    grantedMember: useGetSearchTextSetter(grantedMembersStore),
-    grantableMember: useGetSearchTextSetter(grantableMembersStore),
-    pendingMember: useGetSearchTextSetter(pendingMembersStore),
-    paymentStatus: useGetSearchTextSetter(paymentStatusMembersStore),
+    allMember: useGetSearchTextSetter(useAllMembersStore),
+    grantedMember: useGetSearchTextSetter(useGrantedMembersStore),
+    grantableMember: useGetSearchTextSetter(useGrantableMembersStore),
+    pendingMember: useGetSearchTextSetter(usePendingMembersStore),
+    paymentStatus: useGetSearchTextSetter(usePaymentStatusMembersStore),
   };
 
   return setSearchTextFunctions;

--- a/src/hooks/useGetSearchVariantSetters.ts
+++ b/src/hooks/useGetSearchVariantSetters.ts
@@ -1,24 +1,24 @@
-import { UseBoundStore, StoreApi, useStore } from "zustand";
-import { allMembersStore } from "@/store/allMembers";
-import { grantableMembersStore } from "@/store/grantableMembers";
-import { grantedMembersStore } from "@/store/grantedMembers";
-import { paymentStatusMembersStore } from "@/store/paymentStatusMembers";
-import { pendingMembersStore } from "@/store/pendingMembers";
+import { UseBoundStore, StoreApi } from "zustand";
+import { useAllMembersStore } from "@/store/allMembers";
+import { useGrantableMembersStore } from "@/store/grantableMembers";
+import { useGrantedMembersStore } from "@/store/grantedMembers";
+import { usePaymentStatusMembersStore } from "@/store/paymentStatusMembers";
+import { usePendingMembersStore } from "@/store/pendingMembers";
 import { MemberStoreType } from "@/types/entities/store";
 
 export default function useGetSearchVariantSetters() {
-  const useGetSearchVariantSetter = (store: UseBoundStore<StoreApi<MemberStoreType>>) => {
-    const { setSearchVariant } = useStore(store);
+  const useGetSearchVariantSetter = (useMembersStore: UseBoundStore<StoreApi<MemberStoreType>>) => {
+    const setSearchVariant = useMembersStore(state => state.setSearchVariant);
 
     return setSearchVariant;
   };
 
   const setSearchVariantFunctions = {
-    allMember: useGetSearchVariantSetter(allMembersStore),
-    grantedMember: useGetSearchVariantSetter(grantedMembersStore),
-    grantableMember: useGetSearchVariantSetter(grantableMembersStore),
-    pendingMember: useGetSearchVariantSetter(pendingMembersStore),
-    paymentStatus: useGetSearchVariantSetter(paymentStatusMembersStore),
+    allMember: useGetSearchVariantSetter(useAllMembersStore),
+    grantedMember: useGetSearchVariantSetter(useGrantedMembersStore),
+    grantableMember: useGetSearchVariantSetter(useGrantableMembersStore),
+    pendingMember: useGetSearchVariantSetter(usePendingMembersStore),
+    paymentStatus: useGetSearchVariantSetter(usePaymentStatusMembersStore),
   };
 
   return setSearchVariantFunctions;

--- a/src/store/allMembers.ts
+++ b/src/store/allMembers.ts
@@ -7,7 +7,7 @@ export type AllMembersStoreType = {
   setSearchVariant: (variant: SearchVariantType<"allMember">) => void;
 };
 
-export const allMembersStore = create<AllMembersStoreType>(set => ({
+export const useAllMembersStore = create<AllMembersStoreType>(set => ({
   searchInfo: {
     text: "",
     variant: null,

--- a/src/store/grantableMembers.ts
+++ b/src/store/grantableMembers.ts
@@ -7,7 +7,7 @@ export type GrantableMembersStoreType = {
   setSearchVariant: (variant: SearchVariantType<"grantableMember">) => void;
 };
 
-export const grantableMembersStore = create<GrantableMembersStoreType>(set => ({
+export const useGrantableMembersStore = create<GrantableMembersStoreType>(set => ({
   searchInfo: {
     text: "",
     variant: null,

--- a/src/store/grantedMembers.ts
+++ b/src/store/grantedMembers.ts
@@ -7,7 +7,7 @@ export type GrantedMembersStoreType = {
   setSearchVariant: (variant: SearchVariantType<"grantedMember">) => void;
 };
 
-export const grantedMembersStore = create<GrantedMembersStoreType>(set => ({
+export const useGrantedMembersStore = create<GrantedMembersStoreType>(set => ({
   searchInfo: {
     text: "",
     variant: null,

--- a/src/store/paymentStatusMembers.ts
+++ b/src/store/paymentStatusMembers.ts
@@ -7,7 +7,7 @@ export type PaymentStatusMembersStoreType = {
   setSearchVariant: (variant: SearchVariantType<"paymentStatus">) => void;
 };
 
-export const paymentStatusMembersStore = create<PaymentStatusMembersStoreType>(set => ({
+export const usePaymentStatusMembersStore = create<PaymentStatusMembersStoreType>(set => ({
   searchInfo: {
     text: "",
     variant: null,

--- a/src/store/pendingMembers.ts
+++ b/src/store/pendingMembers.ts
@@ -7,7 +7,7 @@ export type PendingMembersStoreType = {
   setSearchVariant: (variant: SearchVariantType<"pendingMember">) => void;
 };
 
-export const pendingMembersStore = create<PendingMembersStoreType>(set => ({
+export const usePendingMembersStore = create<PendingMembersStoreType>(set => ({
   searchInfo: {
     text: "",
     variant: null,


### PR DESCRIPTION
## Describe your changes
현재는 그냥 해당 상태 전체를 불러와서 구조 분해 할당을 통해 사용하고 있습니다.
예시로, 스토어에 A, B 속성이 있는데 Component1 컴포넌트에서는 A, Component2 컴포넌트에서는 B를 사용하고 있습니다.
두 컴포넌트는 각각 해당 상태 전체를 불러와서 구조 분해 할당을 통해 사용하고 있다면, B 속성이 변경되었을 때 Component1에서도 리렌더링이 발생하게 됩니다.

이를 방지할 수 있게 해주는 것이 selector 함수입니다.
selector 함수를 사용하면 딱 필요한 상태만 가져와서 해당 상태가 리렌더링될 때 해당 컴포넌트만 리렌더링됩니다.

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->