### PR TITLE
[Refactor] 회비 관리 - 쿠폰 관리 페이지 쿠폰 수정 기능 삭제

### DIFF
--- a/src/apis/couponApi.ts
+++ b/src/apis/couponApi.ts
@@ -7,7 +7,7 @@ export const couponApi = {
     return response.data;
   },
 
-  createCoupon: async (body: { name: string; discountAmount: number }) => {
+  createCoupon: async (body: { name: string; discountAmount: number | null }) => {
     const response = await apiClient.post("/admin/coupons", body);
     return response.data;
   },

--- a/src/components/common/Modal/CouponModal.tsx
+++ b/src/components/common/Modal/CouponModal.tsx
@@ -4,26 +4,18 @@ import styled from "@emotion/styled";
 import { Box, Button, Modal, TextField, Typography } from "@mui/material";
 import useCreateCouponMutation from "@/hooks/mutations/useCreateCouponMutation";
 import { useCouponSearchInfoDispatch } from "@/hooks/contexts/useCouponSearchInfoState";
+import { CouponInfoType } from "@/types/entities/coupon";
 
 type CouponModalPropsType = {
   open: boolean;
   onClose: () => void;
-  isEdit?: boolean;
-  defaultValue?: { name: string; discountAmount: number };
 };
 
-export default function CouponModal({
-  open,
-  onClose,
-  isEdit = false,
-  defaultValue,
-}: CouponModalPropsType) {
-  const [couponInfo, setCouponInfo] = useState(
-    defaultValue ?? {
-      name: "",
-      discountAmount: null,
-    },
-  );
+export default function CouponModal({ open, onClose }: CouponModalPropsType) {
+  const [couponInfo, setCouponInfo] = useState<CouponInfoType>({
+    name: "",
+    discountAmount: null,
+  });
 
   const { setModalOpen } = useCouponSearchInfoDispatch();
   const { mutate: createCouponMutate } = useCreateCouponMutation();
@@ -38,18 +30,18 @@ export default function CouponModal({
   };
 
   const handleClickSubmit = () => {
-    if (isEdit) {
+    if (!couponInfo.discountAmount) {
       return;
     }
 
-    couponInfo.discountAmount && createCouponMutate(couponInfo);
+    createCouponMutate(couponInfo);
     setModalOpen(false);
   };
 
   return (
     <Modal open={open} onClose={onClose}>
       <StyledModalContentWrapper>
-        <StyledTitle css={typo.h1}>{isEdit ? "쿠폰 수정" : "쿠폰 생성"}</StyledTitle>
+        <StyledTitle css={typo.h1}>{"쿠폰 생성"}</StyledTitle>
         <StyledContent>
           <StyledInfoRow>
             <StyledInfoWrapper>
@@ -74,7 +66,7 @@ export default function CouponModal({
             </StyledInfoWrapper>
           </StyledInfoRow>
           <StyledButton size="large" variant="contained" onClick={handleClickSubmit}>
-            {isEdit ? "수정하기" : "생성하기"}
+            {"생성하기"}
           </StyledButton>
         </StyledContent>
       </StyledModalContentWrapper>

--- a/src/components/common/Modal/CouponModal.tsx
+++ b/src/components/common/Modal/CouponModal.tsx
@@ -3,7 +3,6 @@ import { typo } from "@/styles/typo";
 import styled from "@emotion/styled";
 import { Box, Button, Modal, TextField, Typography } from "@mui/material";
 import useCreateCouponMutation from "@/hooks/mutations/useCreateCouponMutation";
-import { useCouponSearchInfoDispatch } from "@/hooks/contexts/useCouponSearchInfoState";
 import { CouponInfoType } from "@/types/entities/coupon";
 
 type CouponModalPropsType = {
@@ -17,7 +16,6 @@ export default function CouponModal({ open, onClose }: CouponModalPropsType) {
     discountAmount: null,
   });
 
-  const { setModalOpen } = useCouponSearchInfoDispatch();
   const { mutate: createCouponMutate } = useCreateCouponMutation();
 
   const handleChangeCouponInfo = (e: ChangeEvent<HTMLInputElement | HTMLTextAreaElement>) => {
@@ -35,7 +33,7 @@ export default function CouponModal({ open, onClose }: CouponModalPropsType) {
     }
 
     createCouponMutate(couponInfo);
-    setModalOpen(false);
+    onClose();
   };
 
   return (

--- a/src/components/common/Table/CouponInfoTable.tsx
+++ b/src/components/common/Table/CouponInfoTable.tsx
@@ -10,6 +10,7 @@ import {
 } from "@/hooks/contexts/useCouponSearchInfoState";
 import CouponModal from "../Modal/CouponModal";
 import useDeleteCouponMutation from "@/hooks/mutations/useDeleteCouponMutation";
+import { useRef } from "react";
 
 const mockIssuedCouponList = [
   {
@@ -51,6 +52,8 @@ const mockIssuedCouponList = [
 ];
 
 export default function CouponInfoTable() {
+  const modalKey = useRef(0);
+
   const { modalOpen } = useCouponSearchInfoState();
   const { setModalOpen } = useCouponSearchInfoDispatch();
 
@@ -63,6 +66,7 @@ export default function CouponInfoTable() {
 
   const handleCloseModal = () => {
     setModalOpen(false);
+    modalKey.current += 1;
   };
 
   const getFilteredIssuedCouponList = (couponList: IssuedCouponListResponseDtoType) => {
@@ -86,7 +90,7 @@ export default function CouponInfoTable() {
         disableColumnSorting
         hideFooterPagination
       />
-      <CouponModal key={Date.now()} open={modalOpen} onClose={handleCloseModal} />
+      <CouponModal key={modalKey.current} open={modalOpen} onClose={handleCloseModal} />
     </>
   );
 }

--- a/src/components/common/Table/CouponInfoTable.tsx
+++ b/src/components/common/Table/CouponInfoTable.tsx
@@ -1,5 +1,5 @@
 import styled from "@emotion/styled";
-import { DataGrid, GridCellParams, GridColDef, GridRowModel } from "@mui/x-data-grid";
+import { DataGrid, GridCellParams, GridColDef } from "@mui/x-data-grid";
 // import useGetIssuedCouponListQuery from "@/hooks/queries/useGetIssuedCouponListQuery";
 import { IssuedCouponListResponseDtoType } from "@/types/dtos/coupon";
 import { formatDateWithText } from "@/utils/date";
@@ -10,7 +10,6 @@ import {
 } from "@/hooks/contexts/useCouponSearchInfoState";
 import CouponModal from "../Modal/CouponModal";
 import useDeleteCouponMutation from "@/hooks/mutations/useDeleteCouponMutation";
-import { useState } from "react";
 
 const mockIssuedCouponList = [
   {
@@ -52,47 +51,17 @@ const mockIssuedCouponList = [
 ];
 
 export default function CouponInfoTable() {
-  const [editCouponData, setEditCouponData] = useState({
-    couponId: 0,
-    name: "",
-    discountAmount: 0,
-    createdAt: "",
-  });
-  const [isEdit, setIsEdit] = useState(false);
-
   const { modalOpen } = useCouponSearchInfoState();
   const { setModalOpen } = useCouponSearchInfoDispatch();
 
   //   const issuedCouponList = useGetIssuedCouponListQuery();
   const { mutate: deleteCouponMutate } = useDeleteCouponMutation();
 
-  const handleClickCouponEdit = (row: GridRowModel) => {
-    const { id, name, discountAmount, createdAt } = row;
-
-    setIsEdit(true);
-    setEditCouponData({
-      couponId: id,
-      name,
-      discountAmount,
-      createdAt,
-    });
-    setModalOpen(true);
-  };
-
   const handleClickCouponDelete = (id: number) => {
     deleteCouponMutate(id);
   };
 
   const handleCloseModal = () => {
-    if (isEdit) {
-      setIsEdit(false);
-      setEditCouponData({
-        couponId: 0,
-        name: "",
-        discountAmount: 0,
-        createdAt: "",
-      });
-    }
     setModalOpen(false);
   };
 
@@ -109,7 +78,7 @@ export default function CouponInfoTable() {
     <>
       <StyledDataGrid
         rows={getFilteredIssuedCouponList(mockIssuedCouponList)}
-        columns={getColumns(handleClickCouponDelete, handleClickCouponEdit)}
+        columns={getColumns(handleClickCouponDelete)}
         autoHeight
         disableRowSelectionOnClick
         disableColumnFilter
@@ -117,21 +86,12 @@ export default function CouponInfoTable() {
         disableColumnSorting
         hideFooterPagination
       />
-      <CouponModal
-        key={Date.now()}
-        open={modalOpen}
-        onClose={handleCloseModal}
-        defaultValue={editCouponData}
-        isEdit={isEdit}
-      />
+      <CouponModal key={Date.now()} open={modalOpen} onClose={handleCloseModal} />
     </>
   );
 }
 
-const getColumns = (
-  handleClickCouponDelete: (id: number) => void,
-  handleClickCouponEdit: (row: GridRowModel) => void,
-): GridColDef[] => [
+const getColumns = (handleClickCouponDelete: (id: number) => void): GridColDef[] => [
   {
     field: "name",
     headerName: "이름",
@@ -167,13 +127,6 @@ const getColumns = (
     renderCell: (params: GridCellParams) => {
       return (
         <StyledButtonWrapper>
-          <StyledButton
-            variant="outlined"
-            color="primary"
-            onClick={() => handleClickCouponEdit(params.row)}
-          >
-            수정
-          </StyledButton>
           <StyledButton
             variant="outlined"
             color="error"

--- a/src/types/entities/coupon.ts
+++ b/src/types/entities/coupon.ts
@@ -1,0 +1,4 @@
+export type CouponInfoType = {
+  name: string;
+  discountAmount: null | number;
+};


### PR DESCRIPTION
## Describe your changes
<!-- 스크린샷 및 작업내용을 적어주세요 -->
회비 관리 - 쿠폰 관리 페이지에서 수정 기능이 필요하지 않다고 논의되어 삭제했습니다.
이때, 쿠폰 모달에 넘겨주는 key 값 또한 관리 방식을 변경했는데, 기존에는 Date.key()로 렌더링마다 새로 생성되게 했지만, ref로 modalKey를 관리하도록 수정했습니다.
이렇게 하면 모달이 열고 닫을 때마다 key 값을 변경하게 하여 불필요한 연산 횟수가 줄어듭니다.

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->