### PR TITLE
[Fix] 모집 종료 일자 시간 설정

### DIFF
--- a/src/components/RecruitmentRound/RecruitmentRoundInfoModal.tsx
+++ b/src/components/RecruitmentRound/RecruitmentRoundInfoModal.tsx
@@ -1,4 +1,13 @@
-import { ChangeEvent, useEffect, useState } from "react";
+import { QueryKey } from "@/constants/queryKey";
+import useCreateRecruitmentRoundMutation from "@/hooks/mutations/useCreateRecruitmentRoundMutation";
+import useEditRecruitmentRoundMutation, {
+  EditRecruitmentRoundMutationArgumentType,
+} from "@/hooks/mutations/useEditRecruitmentRoundMutation";
+import {
+  FilteredRecruitmentRoundInfoType,
+  RecruitmentRoundModalInfoType,
+} from "@/types/entities/recruitment";
+import { toKSTISOString } from "@/utils/validation/formatDate";
 import {
   Box,
   Button,
@@ -15,17 +24,8 @@ import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider/LocalizationProvider";
 import { useQueryClient } from "@tanstack/react-query";
 import dayjs, { Dayjs } from "dayjs";
+import { ChangeEvent, useEffect, useState } from "react";
 import { toast } from "react-toastify";
-import { QueryKey } from "@/constants/queryKey";
-import useCreateRecruitmentRoundMutation from "@/hooks/mutations/useCreateRecruitmentRoundMutation";
-import useEditRecruitmentRoundMutation, {
-  EditRecruitmentRoundMutationArgumentType,
-} from "@/hooks/mutations/useEditRecruitmentRoundMutation";
-import {
-  FilteredRecruitmentRoundInfoType,
-  RecruitmentRoundModalInfoType,
-} from "@/types/entities/recruitment";
-import { toKSTISOString } from "@/utils/validation/formatDate";
 
 export type RecruitmentRoundInfoModalPropsType = {
   open: boolean;
@@ -87,9 +87,11 @@ export default function RecruitmentRoundInfoModal({
       return;
     }
 
+    const adjustedDate = name === "endDate" ? newDate.hour(23).minute(59).second(59) : newDate;
+
     setRoundModalInfo(prevModalInfo => ({
       ...prevModalInfo,
-      [name]: newDate,
+      [name]: adjustedDate,
     }));
   };
 

--- a/src/components/RecruitmentRound/RecruitmentRoundInfoModal.tsx
+++ b/src/components/RecruitmentRound/RecruitmentRoundInfoModal.tsx
@@ -87,7 +87,7 @@ export default function RecruitmentRoundInfoModal({
       return;
     }
 
-    const adjustedDate = name === "endDate" ? newDate.hour(23).minute(59).second(59) : newDate;
+    const adjustedDate = name === "endDate" ? newDate.endOf("day") : newDate;
 
     setRoundModalInfo(prevModalInfo => ({
       ...prevModalInfo,


### PR DESCRIPTION
## Describe your changes
모집 종료 시간을 선택한 날짜의 23:59:59로 수정했습니다.

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **버그 수정**
  - 모집 라운드 종료일을 선택한 날짜의 끝(23:59:59)으로 자동 보정하여 조기 종료를 방지하고 일정 표시/필터링의 일관성을 개선했습니다.

- **리팩터링**
  - 생성/수정 흐름의 날짜 포맷을 KST 기준의 일관된 ISO 문자열로 정리하고, 데이터 처리 타입 안정성과 로직을 정비해 모집 라운드 정보 저장 신뢰성을 향상했습니다.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->