### PR TITLE
feat: 폼 수정

### DIFF
--- a/src/components/EditEvent/AfterPartyManagement.tsx
+++ b/src/components/EditEvent/AfterPartyManagement.tsx
@@ -1,0 +1,206 @@
+import { useState, useMemo } from "react";
+import { css } from "@emotion/react";
+import { color, space } from "wowds-tokens";
+import Button from "wowds-ui/Button";
+import Checkbox from "wowds-ui/Checkbox";
+import Table from "wowds-ui/Table";
+import { Flex } from "../@common/Flex";
+import { Space } from "../@common/Space";
+import { Text } from "../@common/Text";
+import { mockAfterPartyData, type AfterPartyData } from "./mockData/afterPartyMockData";
+
+export const AfterPartyManagement = () => {
+  const [data, setData] = useState<AfterPartyData>(mockAfterPartyData);
+
+  const participants = data.applicants.content;
+  const counts = data.counts;
+
+  // 통계 계산
+  const stats = useMemo(() => {
+    const total = participants.length;
+    const prePaymentCount = counts.prePaymentPaidCount;
+    const afterPartyCount = counts.afterPartyAttendedCount;
+    const settlementCount = counts.postPaymentPaidCount;
+
+    return {
+      total,
+      prePayment: { count: prePaymentCount, total },
+      afterParty: { count: afterPartyCount, total },
+      settlement: { count: settlementCount, total },
+    };
+  }, [participants, counts]);
+
+  // 체크박스 변경 핸들러
+  const handleCheckboxChange = (
+    participantId: number,
+    field: "prePayment" | "afterPartyAttendance" | "postPayment",
+  ) => {
+    setData(prev => ({
+      ...prev,
+      applicants: {
+        ...prev.applicants,
+        content: prev.applicants.content.map(p => {
+          if (p.eventParticipationId === participantId) {
+            switch (field) {
+              case "prePayment":
+                return {
+                  ...p,
+                  prePaymentStatus: p.prePaymentStatus === "PAID" ? "NOT_PAID" : "PAID",
+                };
+              case "afterPartyAttendance":
+                return {
+                  ...p,
+                  afterPartyAttendanceStatus:
+                    p.afterPartyAttendanceStatus === "ATTENDED" ? "NOT_ATTENDED" : "ATTENDED",
+                };
+              case "postPayment":
+                return {
+                  ...p,
+                  postPaymentStatus: p.postPaymentStatus === "PAID" ? "NOT_PAID" : "PAID",
+                };
+              default:
+                return p;
+            }
+          }
+          return p;
+        }),
+      },
+    }));
+  };
+
+  // 전체 선택/해제 핸들러
+  const handleSelectAll = (field: "prePayment" | "afterPartyAttendance" | "postPayment") => {
+    const allChecked = participants.every(p => {
+      switch (field) {
+        case "prePayment":
+          return p.prePaymentStatus === "PAID";
+        case "afterPartyAttendance":
+          return p.afterPartyAttendanceStatus === "ATTENDED";
+        case "postPayment":
+          return p.postPaymentStatus === "PAID";
+        default:
+          return false;
+      }
+    });
+
+    setData(prev => ({
+      ...prev,
+      applicants: {
+        ...prev.applicants,
+        content: prev.applicants.content.map(p => {
+          switch (field) {
+            case "prePayment":
+              return { ...p, prePaymentStatus: allChecked ? "NOT_PAID" : "PAID" };
+            case "afterPartyAttendance":
+              return { ...p, afterPartyAttendanceStatus: allChecked ? "NOT_ATTENDED" : "ATTENDED" };
+            case "postPayment":
+              return { ...p, postPaymentStatus: allChecked ? "NOT_PAID" : "PAID" };
+            default:
+              return p;
+          }
+        }),
+      },
+    }));
+  };
+
+  return (
+    <div
+      css={css({
+        backgroundColor: color.backgroundAlternative,
+        padding: "30px",
+        borderRadius: space.md,
+        marginTop: "30px",
+      })}
+    >
+      <Text typo="h2">뒤풀이 관리</Text>
+      <Space height="lg" />
+
+      <Table fullWidth>
+        <Table.Thead>
+          <Table.Th>이름</Table.Th>
+          <Table.Th>학번</Table.Th>
+          <Table.Th>전화번호</Table.Th>
+          <Table.Th>
+            <Flex align="center" gap="sm">
+              <Text typo="body1">선입금 납부</Text>
+              <Text typo="body2" color="primary">
+                {stats.prePayment.count}/{stats.prePayment.total}
+              </Text>
+              <Checkbox
+                checked={
+                  stats.prePayment.count === stats.prePayment.total && stats.prePayment.count > 0
+                }
+                onChange={() => handleSelectAll("prePayment")}
+              />
+            </Flex>
+          </Table.Th>
+          <Table.Th>
+            <Flex align="center" gap="sm">
+              <Text typo="body1">뒤풀이 참여</Text>
+              <Text typo="body2" color="primary">
+                {stats.afterParty.count}/{stats.afterParty.total}
+              </Text>
+              <Checkbox
+                checked={
+                  stats.afterParty.count === stats.afterParty.total && stats.afterParty.count > 0
+                }
+                onChange={() => handleSelectAll("afterPartyAttendance")}
+              />
+            </Flex>
+          </Table.Th>
+          <Table.Th>
+            <Flex align="center" gap="sm">
+              <Text typo="body1">정산 확인</Text>
+              <Text typo="body2" color="primary">
+                {stats.settlement.count}/{stats.settlement.total}
+              </Text>
+              <Checkbox
+                checked={
+                  stats.settlement.count === stats.settlement.total && stats.settlement.count > 0
+                }
+                onChange={() => handleSelectAll("postPayment")}
+              />
+            </Flex>
+          </Table.Th>
+        </Table.Thead>
+
+        <Table.Tbody>
+          {participants.map(participant => (
+            <Table.Tr
+              key={participant.eventParticipationId}
+              value={participant.eventParticipationId}
+            >
+              <Table.Td>{participant.participant.name}</Table.Td>
+              <Table.Td>{participant.participant.studentId}</Table.Td>
+              <Table.Td>{participant.participant.phone}</Table.Td>
+              <Table.Td>
+                <Checkbox
+                  checked={participant.prePaymentStatus === "PAID"}
+                  onChange={() =>
+                    handleCheckboxChange(participant.eventParticipationId, "prePayment")
+                  }
+                />
+              </Table.Td>
+              <Table.Td>
+                <Checkbox
+                  checked={participant.afterPartyAttendanceStatus === "ATTENDED"}
+                  onChange={() =>
+                    handleCheckboxChange(participant.eventParticipationId, "afterPartyAttendance")
+                  }
+                />
+              </Table.Td>
+              <Table.Td>
+                <Checkbox
+                  checked={participant.postPaymentStatus === "PAID"}
+                  onChange={() =>
+                    handleCheckboxChange(participant.eventParticipationId, "postPayment")
+                  }
+                />
+              </Table.Td>
+            </Table.Tr>
+          ))}
+        </Table.Tbody>
+      </Table>
+    </div>
+  );
+};

--- a/src/components/EditEvent/AfterPartyManagement.tsx
+++ b/src/components/EditEvent/AfterPartyManagement.tsx
@@ -1,7 +1,6 @@
 import { useState, useMemo } from "react";
 import { css } from "@emotion/react";
 import { color, space } from "wowds-tokens";
-import Button from "wowds-ui/Button";
 import Checkbox from "wowds-ui/Checkbox";
 import Table from "wowds-ui/Table";
 import { Flex } from "../@common/Flex";

--- a/src/components/EditEvent/EventForm.tsx
+++ b/src/components/EditEvent/EventForm.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from "react";
 import { css } from "@emotion/react";
+import { Link as LinkIcon } from "wowds-icons";
 import { typography } from "wowds-tokens";
 import Button from "wowds-ui/Button";
 import { FormField } from "./FormField";
@@ -226,7 +227,10 @@ export const EventForm = ({
   return (
     <div>
       <Space height={16} />
-      <Flex justify="end">
+      <Flex justify="end" gap="sm">
+        <Button size="sm" variant="sub" icon={<LinkIcon />}>
+          URL 복사하기
+        </Button>
         <Button
           size="sm"
           onClick={handlePublish}
@@ -236,9 +240,7 @@ export const EventForm = ({
             ? eventId
               ? "수정 중..."
               : "게시 중..."
-            : eventId
-              ? "수정하기"
-              : "게시하기"}
+            : "저장하기"}
         </Button>
       </Flex>
       <Space height={30} />

--- a/src/components/EditEvent/EventForm.tsx
+++ b/src/components/EditEvent/EventForm.tsx
@@ -7,7 +7,6 @@ import { FormField } from "./FormField";
 import { FormFieldProps } from "./FormField";
 import { Flex } from "../@common/Flex";
 import { Space } from "../@common/Space";
-import { useCreateEventMutation } from "@/hooks/mutations/useCreateEventMutation";
 import { useUpdateEventFormMutation } from "@/hooks/mutations/useUpdateEventFormMutation";
 import { EventType, UpdateEventFormRequest } from "@/types/dtos/event";
 const getFormFields = (formValue: EventType | null): FormFieldProps[] => {
@@ -93,7 +92,6 @@ export const EventForm = ({
     Object.fromEntries(formFields.map(field => [field.id, true])),
   );
 
-  const createEventMutation = useCreateEventMutation();
   const updateEventFormMutation = useUpdateEventFormMutation();
 
   const handleRequiredToggle = (id: string, next: boolean) => {
@@ -222,6 +220,9 @@ export const EventForm = ({
           },
         },
       );
+    } else {
+      // 새 이벤트 생성은 EventInformation에서 처리되므로 여기서는 폼 정보만 업데이트
+      console.log("새 이벤트 생성은 기본 정보 입력 후 처리됩니다.");
     }
   };
   return (
@@ -231,16 +232,8 @@ export const EventForm = ({
         <Button size="sm" variant="sub" icon={<LinkIcon />}>
           URL 복사하기
         </Button>
-        <Button
-          size="sm"
-          onClick={handlePublish}
-          disabled={createEventMutation.isPending || updateEventFormMutation.isPending}
-        >
-          {createEventMutation.isPending || updateEventFormMutation.isPending
-            ? eventId
-              ? "수정 중..."
-              : "게시 중..."
-            : "저장하기"}
+        <Button size="sm" onClick={handlePublish} disabled={updateEventFormMutation.isPending}>
+          {updateEventFormMutation.isPending ? "수정 중..." : "저장하기"}
         </Button>
       </Flex>
       <Space height={30} />

--- a/src/components/EditEvent/EventInformation.tsx
+++ b/src/components/EditEvent/EventInformation.tsx
@@ -222,6 +222,7 @@ export const EventInformation = ({
     }
   };
 
+  console.log(formValue);
   return (
     <>
       <div
@@ -433,48 +434,53 @@ export const EventInformation = ({
               )}
             </div>
             <div style={{ flex: "0 0 calc(50% - 8px)" }}>
-              <Text typo="body1" style={{ marginBottom: "8px" }}>
-                뒤풀이 인원 제한
-              </Text>
-              <Flex gap="sm" style={{ marginBottom: "8px", justifyContent: "left" }}>
-                <label>
-                  <input
-                    type="radio"
-                    name="afterPartyLimit"
-                    checked={!afterPartyLimitEnabled}
-                    onChange={() => setAfterPartyLimitEnabled(false)}
-                    style={{ marginRight: "4px" }}
-                  />
-                  없음
-                </label>
-                <label>
-                  <input
-                    type="radio"
-                    name="afterPartyLimit"
-                    checked={afterPartyLimitEnabled}
-                    onChange={() => setAfterPartyLimitEnabled(true)}
-                    style={{ marginRight: "4px" }}
-                  />
-                  있음
-                </label>
-              </Flex>
-              {afterPartyLimitEnabled && (
-                <TextField
-                  label="제한 인원"
-                  placeholder="제한 인원(20)"
-                  value={afterPartyMaxCount}
-                  onChange={handleAfterPartyMaxCountChange}
-                  variant="outlined"
-                  fullWidth
-                  type="number"
-                  style={{ backgroundColor: "white" }}
-                  inputProps={{
-                    min: totalAttendeesCount > 0 ? totalAttendeesCount : 1,
-                    pattern: "[0-9]*",
-                    inputMode: "numeric",
-                  }}
-                  size="small"
-                />
+              {eventId && formValue?.afterPartyStatus === "ENABLED" && (
+                <>
+                  <Text typo="body1" style={{ marginBottom: "8px" }}>
+                    뒤풀이 인원 제한
+                  </Text>
+                  <Flex gap="sm" style={{ marginBottom: "8px", justifyContent: "left" }}>
+                    <label>
+                      <input
+                        type="radio"
+                        name="afterPartyLimit"
+                        checked={!afterPartyLimitEnabled}
+                        onChange={() => setAfterPartyLimitEnabled(false)}
+                        style={{ marginRight: "4px" }}
+                      />
+                      없음
+                    </label>
+                    <label>
+                      <input
+                        type="radio"
+                        name="afterPartyLimit"
+                        checked={afterPartyLimitEnabled}
+                        onChange={() => setAfterPartyLimitEnabled(true)}
+                        style={{ marginRight: "4px" }}
+                      />
+                      있음
+                    </label>
+                  </Flex>
+
+                  {afterPartyLimitEnabled && (
+                    <TextField
+                      label="제한 인원"
+                      placeholder="제한 인원(20)"
+                      value={afterPartyMaxCount}
+                      onChange={handleAfterPartyMaxCountChange}
+                      variant="outlined"
+                      fullWidth
+                      type="number"
+                      style={{ backgroundColor: "white" }}
+                      inputProps={{
+                        min: totalAttendeesCount > 0 ? totalAttendeesCount : 1,
+                        pattern: "[0-9]*",
+                        inputMode: "numeric",
+                      }}
+                      size="small"
+                    />
+                  )}
+                </>
               )}
             </div>
           </Flex>
@@ -484,9 +490,7 @@ export const EventInformation = ({
           size="sm"
           disabled={createEventMutation.isPending || updateBasicInfoMutation.isPending}
         >
-          {createEventMutation.isPending || updateBasicInfoMutation.isPending
-            ? "저장 중..."
-            : "저장"}
+          {eventId ? "저장하기" : "게시하기"}
         </Button>
       </div>
     </>

--- a/src/components/EditEvent/EventInformation.tsx
+++ b/src/components/EditEvent/EventInformation.tsx
@@ -19,6 +19,7 @@ import { color, space } from "wowds-tokens";
 import Button from "wowds-ui/Button";
 import DropDown from "wowds-ui/DropDown";
 import DropDownOption from "wowds-ui/DropDownOption";
+import { CopyUrlModal } from "./Modal/CopyUrlModal";
 import { Flex } from "@/components/@common/Flex";
 import { Space } from "@/components/@common/Space";
 import { Text } from "@/components/@common/Text";
@@ -89,6 +90,7 @@ export const EventInformation = ({
   const [afterPartyLimitEnabled, setAfterPartyLimitEnabled] = useState<boolean>(
     eventId ? (formValue?.afterPartyMaxApplicantCount || 0) > 0 : true,
   );
+  const [copyUrlModalOpen, setCopyUrlModalOpen] = useState(false);
 
   // 신청 기간이 지났는지 확인하는 함수
   const isApplicationInPeriod = () => {
@@ -213,6 +215,8 @@ export const EventInformation = ({
       createEventMutation.mutate(basicInfoData, {
         onSuccess: data => {
           updateFormValues();
+          setCopyUrlModalOpen(true);
+          eventUrl = `https://event.wawoo.dev/1`;
           console.log("이벤트가 성공적으로 생성되었습니다:", data);
         },
         onError: error => {
@@ -222,7 +226,9 @@ export const EventInformation = ({
     }
   };
 
-  console.log(formValue);
+  // 이벤트 URL 생성
+  let eventUrl = `https://event.wawoo.dev/${eventId}`;
+
   return (
     <>
       <div
@@ -493,6 +499,13 @@ export const EventInformation = ({
           {eventId ? "저장하기" : "게시하기"}
         </Button>
       </div>
+
+      {/* URL 복사 모달 */}
+      <CopyUrlModal
+        open={copyUrlModalOpen}
+        onClose={() => setCopyUrlModalOpen(false)}
+        url={eventUrl}
+      />
     </>
   );
 };

--- a/src/components/EditEvent/Modal/CopyUrlModal.tsx
+++ b/src/components/EditEvent/Modal/CopyUrlModal.tsx
@@ -1,10 +1,9 @@
-import React, { useState } from "react";
-import { Modal } from "@mui/material";
+import { useState } from "react";
 import { css } from "@emotion/react";
+import { Modal } from "@mui/material";
 import { color, space } from "wowds-tokens";
 import Button from "wowds-ui/Button";
 import TextField from "wowds-ui/TextField";
-import { Flex } from "@/components/@common/Flex";
 import { Space } from "@/components/@common/Space";
 import { Text } from "@/components/@common/Text";
 
@@ -60,17 +59,14 @@ export const CopyUrlModal = ({ open, onClose, url }: CopyUrlModalProps) => {
         <button
           onClick={onClose}
           css={css({
-            "position": "absolute",
-            "top": "16px",
-            "right": "16px",
-            "background": "none",
-            "border": "none",
-            "fontSize": "20px",
-            "cursor": "pointer",
-            "color": color.sub,
-            "&:hover": {
-              color: color.text,
-            },
+            position: "absolute",
+            top: "16px",
+            right: "16px",
+            background: "none",
+            border: "none",
+            fontSize: "20px",
+            cursor: "pointer",
+            color: color.sub,
           })}
         >
           ×
@@ -88,10 +84,8 @@ export const CopyUrlModal = ({ open, onClose, url }: CopyUrlModalProps) => {
 
         {/* URL 입력 필드 */}
         <TextField
-          id="url-input"
+          label={""}
           value={url}
-          readOnly
-          fullWidth
           css={css({
             "& .MuiInputBase-root": {
               "backgroundColor": color.backgroundAlternative,
@@ -100,19 +94,6 @@ export const CopyUrlModal = ({ open, onClose, url }: CopyUrlModalProps) => {
               },
             },
           })}
-          InputProps={{
-            startAdornment: (
-              <span
-                css={css({
-                  marginRight: "8px",
-                  color: color.sub,
-                  fontSize: "16px",
-                })}
-              >
-                🔗
-              </span>
-            ),
-          }}
         />
 
         <Space height="lg" />
@@ -120,7 +101,6 @@ export const CopyUrlModal = ({ open, onClose, url }: CopyUrlModalProps) => {
         {/* 복사 버튼 */}
         <Button
           onClick={handleCopyUrl}
-          fullWidth
           size="lg"
           css={css({
             "backgroundColor": copied ? color.success : color.primary,

--- a/src/components/EditEvent/Modal/CopyUrlModal.tsx
+++ b/src/components/EditEvent/Modal/CopyUrlModal.tsx
@@ -1,0 +1,137 @@
+import React, { useState } from "react";
+import { Modal } from "@mui/material";
+import { css } from "@emotion/react";
+import { color, space } from "wowds-tokens";
+import Button from "wowds-ui/Button";
+import TextField from "wowds-ui/TextField";
+import { Flex } from "@/components/@common/Flex";
+import { Space } from "@/components/@common/Space";
+import { Text } from "@/components/@common/Text";
+
+interface CopyUrlModalProps {
+  open: boolean;
+  onClose: () => void;
+  url: string;
+}
+
+export const CopyUrlModal = ({ open, onClose, url }: CopyUrlModalProps) => {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopyUrl = async () => {
+    try {
+      await navigator.clipboard.writeText(url);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000); // 2초 후 복사 상태 초기화
+    } catch (err) {
+      console.error("URL 복사 실패:", err);
+      // fallback: 텍스트 선택 방식
+      const textField = document.getElementById("url-input") as HTMLInputElement;
+      if (textField) {
+        textField.select();
+        document.execCommand("copy");
+        setCopied(true);
+        setTimeout(() => setCopied(false), 2000);
+      }
+    }
+  };
+
+  return (
+    <Modal
+      open={open}
+      onClose={onClose}
+      css={css({
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+      })}
+    >
+      <div
+        css={css({
+          backgroundColor: "white",
+          borderRadius: space.md,
+          padding: "32px",
+          width: "400px",
+          maxWidth: "90vw",
+          position: "relative",
+          boxShadow: "0 4px 20px rgba(0, 0, 0, 0.15)",
+        })}
+      >
+        {/* 닫기 버튼 */}
+        <button
+          onClick={onClose}
+          css={css({
+            "position": "absolute",
+            "top": "16px",
+            "right": "16px",
+            "background": "none",
+            "border": "none",
+            "fontSize": "20px",
+            "cursor": "pointer",
+            "color": color.sub,
+            "&:hover": {
+              color: color.text,
+            },
+          })}
+        >
+          ×
+        </button>
+
+        {/* 제목 */}
+        <Text typo="h3" style={{ marginBottom: "24px", textAlign: "center" }}>
+          행사 폼이 게시되었어요.
+        </Text>
+
+        {/* 링크 라벨 */}
+        <Text typo="body1" style={{ marginBottom: "8px" }}>
+          행사 폼 링크
+        </Text>
+
+        {/* URL 입력 필드 */}
+        <TextField
+          id="url-input"
+          value={url}
+          readOnly
+          fullWidth
+          css={css({
+            "& .MuiInputBase-root": {
+              "backgroundColor": color.backgroundAlternative,
+              "&:hover": {
+                backgroundColor: color.backgroundAlternative,
+              },
+            },
+          })}
+          InputProps={{
+            startAdornment: (
+              <span
+                css={css({
+                  marginRight: "8px",
+                  color: color.sub,
+                  fontSize: "16px",
+                })}
+              >
+                🔗
+              </span>
+            ),
+          }}
+        />
+
+        <Space height="lg" />
+
+        {/* 복사 버튼 */}
+        <Button
+          onClick={handleCopyUrl}
+          fullWidth
+          size="lg"
+          css={css({
+            "backgroundColor": copied ? color.success : color.primary,
+            "&:hover": {
+              backgroundColor: copied ? color.success : color.primary,
+            },
+          })}
+        >
+          {copied ? "복사 완료!" : "링크 복사하기"}
+        </Button>
+      </div>
+    </Modal>
+  );
+};

--- a/src/components/EditEvent/mockData/afterPartyMockData.ts
+++ b/src/components/EditEvent/mockData/afterPartyMockData.ts
@@ -1,0 +1,71 @@
+// API 응답 타입 정의
+export interface Participant {
+  name: string;
+  studentId: string;
+  phone: string;
+}
+
+export interface AfterPartyParticipant {
+  eventParticipationId: number;
+  participant: Participant;
+  memberId: number;
+  mainEventApplicationStatus: "NOT_APPLIED" | "APPLIED";
+  afterPartyApplicationStatus: "NONE" | "NOT_APPLIED" | "APPLIED";
+  afterPartyAttendanceStatus: "NONE" | "NOT_ATTENDED" | "ATTENDED";
+  prePaymentStatus: "NONE" | "NOT_PAID" | "PAID";
+  postPaymentStatus: "NONE" | "NOT_PAID" | "PAID";
+}
+
+export interface AfterPartyData {
+  applicants: {
+    totalElements: number;
+    totalPages: number;
+    size: number;
+    content: AfterPartyParticipant[];
+    number: number;
+    numberOfElements: number;
+    first: boolean;
+    last: boolean;
+    empty: boolean;
+  };
+  counts: {
+    afterPartyAppliedCount: number;
+    prePaymentPaidCount: number;
+    afterPartyAttendedCount: number;
+    postPaymentPaidCount: number;
+  };
+}
+
+// Mock 데이터
+export const mockAfterPartyData: AfterPartyData = {
+  applicants: {
+    totalElements: 12,
+    totalPages: 1,
+    size: 20,
+    content: Array.from({ length: 12 }, (_, index) => ({
+      eventParticipationId: index + 1,
+      participant: {
+        name: "장린",
+        studentId: "(20)C046135",
+        phone: "010-1234-5678",
+      },
+      memberId: index + 1,
+      mainEventApplicationStatus: "APPLIED" as const,
+      afterPartyApplicationStatus: "APPLIED" as const,
+      afterPartyAttendanceStatus: "NOT_ATTENDED" as const,
+      prePaymentStatus: index < 3 ? "PAID" : "NOT_PAID",
+      postPaymentStatus: "NOT_PAID" as const,
+    })),
+    number: 0,
+    numberOfElements: 12,
+    first: true,
+    last: true,
+    empty: false,
+  },
+  counts: {
+    afterPartyAppliedCount: 12,
+    prePaymentPaidCount: 3,
+    afterPartyAttendedCount: 0,
+    postPaymentPaidCount: 0,
+  },
+};

--- a/src/components/EditEvent/mockData/afterPartyMockData.ts
+++ b/src/components/EditEvent/mockData/afterPartyMockData.ts
@@ -69,3 +69,5 @@ export const mockAfterPartyData: AfterPartyData = {
     postPaymentPaidCount: 0,
   },
 };
+
+

--- a/src/pages/EditEventPage.tsx
+++ b/src/pages/EditEventPage.tsx
@@ -66,28 +66,32 @@ export const EditEventPage = () => {
         totalAttendeesCount={eventData?.totalAttendeesCount || 0}
       />
 
-      <Space height={54} />
-      <Tabs defaultValue="tab1">
-        <TabsList>
-          <TabsItem value="tab1">행사 신청 폼</TabsItem>
-          <TabsItem value="tab2">신청 인원</TabsItem>
-          <TabsItem value="tab3">뒤풀이 인원</TabsItem>
-        </TabsList>
-        <TabsContent value="tab1">
-          <EventForm
-            formValue={formValues}
-            setFormValues={setformValues}
-            eventId={id || undefined}
-            totalAttendeesCount={eventData?.totalAttendeesCount || 0}
-          />
-        </TabsContent>
-        <TabsContent value="tab2">
-          <ApplyMember title={formValues?.name || ""} />
-        </TabsContent>
-        <TabsContent value="tab3">
-          <AfterPartyManagement />
-        </TabsContent>
-      </Tabs>
+      {eventIdParam !== "new" && (
+        <>
+          <Space height={54} />
+          <Tabs defaultValue="tab1">
+            <TabsList>
+              <TabsItem value="tab1">행사 신청 폼</TabsItem>
+              <TabsItem value="tab2">신청 인원</TabsItem>
+              <TabsItem value="tab3">뒤풀이 인원</TabsItem>
+            </TabsList>
+            <TabsContent value="tab1">
+              <EventForm
+                formValue={formValues}
+                setFormValues={setformValues}
+                eventId={id || undefined}
+                totalAttendeesCount={eventData?.totalAttendeesCount || 0}
+              />
+            </TabsContent>
+            <TabsContent value="tab2">
+              <ApplyMember title={formValues?.name || ""} />
+            </TabsContent>
+            <TabsContent value="tab3">
+              <AfterPartyManagement />
+            </TabsContent>
+          </Tabs>
+        </>
+      )}
     </>
   );
 };

--- a/src/pages/EditEventPage.tsx
+++ b/src/pages/EditEventPage.tsx
@@ -5,6 +5,7 @@ import TabsContent from "wowds-ui/TabsContent";
 import TabsItem from "wowds-ui/TabsItem";
 import TabsList from "wowds-ui/TabsList";
 import { Space } from "@/components/@common/Space";
+import { AfterPartyManagement } from "@/components/EditEvent/AfterPartyManagement";
 import { ApplyMember } from "@/components/EditEvent/ApplyMembers";
 import { EventForm } from "@/components/EditEvent/EventForm";
 import { EventInformation } from "@/components/EditEvent/EventInformation";
@@ -70,6 +71,7 @@ export const EditEventPage = () => {
         <TabsList>
           <TabsItem value="tab1">행사 신청 폼</TabsItem>
           <TabsItem value="tab2">신청 인원</TabsItem>
+          <TabsItem value="tab3">뒤풀이 인원</TabsItem>
         </TabsList>
         <TabsContent value="tab1">
           <EventForm
@@ -80,7 +82,10 @@ export const EditEventPage = () => {
           />
         </TabsContent>
         <TabsContent value="tab2">
-          <ApplyMember title={formValues?.name || ""}/>
+          <ApplyMember title={formValues?.name || ""} />
+        </TabsContent>
+        <TabsContent value="tab3">
+          <AfterPartyManagement />
         </TabsContent>
       </Tabs>
     </>


### PR DESCRIPTION
## Describe your changes
<!-- 스크린샷 및 작업내용을 적어주세요 -->

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- 신기능
  - 편집 페이지에 ‘뒤풀이 인원’ 탭 추가: 참석/선결제/정산 상태를 개별·일괄 토글하고 합계 카운트를 실시간 표시.
  - 이벤트 생성 직후 이벤트 URL을 복사할 수 있는 모달 추가(복사 버튼 및 성공 피드백 포함).
  - 이벤트 편집 화면의 액션 단순화: “URL 복사하기” 버튼 추가 및 저장 동작을 기존 생성 흐름과 분리하여 저장(저장하기) 중심으로 변경.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->