### PR TITLE
Fix: 코드래빗 리뷰 반영

### DIFF
--- a/src/components/AfterPartyAttendance/AfterPartyBottomSearch.tsx
+++ b/src/components/AfterPartyAttendance/AfterPartyBottomSearch.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import styled from "@emotion/styled";
 import { Button } from "@mui/material";
 import { color } from "wowds-tokens";
@@ -9,22 +9,31 @@ export default function AfterPartyBottomSearch({
   handleParticipantAdded,
   handleSearch,
   setSearchTerm,
+  searchTerm,
 }: {
   handleParticipantAdded: () => void;
   handleSearch: () => void;
   setSearchTerm: (term: string) => void;
+  searchTerm: string;
 }) {
   const [isSearching, setIsSearching] = useState(false);
-  const handleInputChange = (e: React.ChangeEvent<HTMLInputElement>) => {
-    setSearchTerm(e.target.value);
-    setIsSearching(e.target.value.length > 0);
-  };
+
+  useEffect(() => {
+    setIsSearching(searchTerm.length > 0);
+  }, [searchTerm]);
 
   return (
     <BottomSheetWrapper onClick={e => e.stopPropagation()}>
       <InputWrapper>
         <Search />
-        <Input type="text" placeholder="이름을 입력하세요" onChange={handleInputChange} />
+        <Input
+          type="text"
+          placeholder="이름을 입력하세요"
+          onChange={(e: React.ChangeEvent<HTMLInputElement>) => {
+            setSearchTerm(e.target.value);
+          }}
+          value={searchTerm}
+        />
       </InputWrapper>
       {isSearching ? (
         <SearchButton variant="contained" onClick={handleSearch}>

--- a/src/components/AfterPartyAttendance/BottomSheet/AfterPartyMemberBottomSheet.tsx
+++ b/src/components/AfterPartyAttendance/BottomSheet/AfterPartyMemberBottomSheet.tsx
@@ -28,6 +28,7 @@ const AfterPartyMemberBottomSheet = ({
       <MemberWrapper>
         {searchResults.map(member => (
           <MemberSelect
+            key={member.studentId}
             name={member.name}
             SID={member.studentId}
             onSelect={() => {

--- a/src/components/AfterPartyAttendance/BottomSheet/AfterPartyNotFoundInternal.tsx
+++ b/src/components/AfterPartyAttendance/BottomSheet/AfterPartyNotFoundInternal.tsx
@@ -21,6 +21,7 @@ const AfterPartyNotFoundInternal = ({
   onCloseBottomSheet,
   handleAddNotFoundMember,
   phone,
+  studentId,
   setPhone,
   setStudentId,
   invalidMessage,
@@ -96,6 +97,7 @@ const AfterPartyNotFoundInternal = ({
             type="text"
             placeholder="학번을 입력하세요"
             onChange={handleSIDChange}
+            value={studentId}
             maxLength={7}
           />
         </MemberInputWrapper>

--- a/src/pages/AfterPartyAttendancePage.tsx
+++ b/src/pages/AfterPartyAttendancePage.tsx
@@ -131,6 +131,7 @@ export default function AfterPartyAttendancePage() {
     setIsBottomSheetOpen(false);
     setNotFound(false); // notFound 케이스면 함께 리셋 추천
     setSearchName("");
+    setSearchTerm("");
   };
 
   const handleSearchParticipant = () => {
@@ -167,12 +168,12 @@ export default function AfterPartyAttendancePage() {
         searchName={searchName}
         handleNotFoundName={handleNotFoundName}
       />
-      {/* 바텀시트 구현 필요 */}
       {isEditMode && (
         <AfterPartyBottomSearch
           handleParticipantAdded={handleParticipantAdded}
           handleSearch={handleSearchParticipant}
           setSearchTerm={setSearchTerm}
+          searchTerm={searchTerm}
         />
       )}
       {isBottomSheetOpen && (


### PR DESCRIPTION
동기화 및 버퍼 지우기

<img width="848" height="572" alt="스크린샷 2025-11-10 오후 4 46 00" src="https://github.com/user-attachments/assets/88567bbd-92d1-443e-b8b6-ab266615c932" />

입력칸에 버퍼가 안남게 함

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 하단 시트를 닫을 때 검색 상태가 제대로 초기화됩니다.

* **리팩토링**
  * 검색 기능의 상태 관리 흐름이 개선되어 더 안정적인 검색 동작을 제공합니다.
  * 멤버 목록 표시 성능이 최적화되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->