### PR TITLE
refactor: useGetSpecificEventQuery 훅으로 마이그레이션 #178

### DIFF
--- a/package.json
+++ b/package.json
@@ -74,5 +74,6 @@
       "eslint --fix",
       "prettier --write"
     ]
-  }
+  },
+  "packageManager": "pnpm@10.19.0+sha512.c9fc7236e92adf5c8af42fd5bf1612df99c2ceb62f27047032f4720b33f8eacdde311865e91c411f2774f618d82f320808ecb51718bfa82c060c4ba7c76a32b8"
 }

--- a/src/pages/AfterPartyAttendancePage.tsx
+++ b/src/pages/AfterPartyAttendancePage.tsx
@@ -12,7 +12,7 @@ import { QueryKey } from "@/constants/queryKey";
 import usePutAfterPartyAttendanceMutation from "@/hooks/mutations/usePutAfterPartyAttendancesMutation";
 import useRevokeAfterPartyAttendanceMutation from "@/hooks/mutations/useRevokeAfterPartyAttendanceMutation";
 import useGetAfterPartyAttendancesQuery from "@/hooks/queries/useGetAfterPartyAttendancesQuery";
-import { useGetEvent } from "@/hooks/queries/useGetEvent";
+import { useGetSpecificEventQuery } from "@/hooks/queries/useGetSpecificEvent";
 
 export default function AfterPartyAttendancePage() {
   const [isEditMode, setIsEditMode] = useState(false);
@@ -33,7 +33,7 @@ export default function AfterPartyAttendancePage() {
     onSiteApplicationCount,
   } = useGetAfterPartyAttendancesQuery(eventId);
 
-  const eventData = useGetEvent(eventId);
+  const eventData = useGetSpecificEventQuery(eventId);
 
   const initialSelectedIds = useMemo(
     () =>
@@ -142,7 +142,7 @@ export default function AfterPartyAttendancePage() {
     <MobileLayout
       header={
         <AfterPartyAttendanceHeader
-          headerTitle={eventData.data?.eventData?.name || "뒤풀이 참석자 관리"}
+          headerTitle={eventData.data?.name || "뒤풀이 참석자 관리"}
           onEditClick={() => {
             if (isEditMode) {
               handleSave();


### PR DESCRIPTION
## Describe your changes
<!-- 스크린샷 및 작업내용을 적어주세요 -->

AfterPartyAttendancePage.tsx에서 useGetEvent 훅을 useGetSpecificEventQuery로 교체하고, 변경된 데이터 구조에 맞게 사용법을 업데이트

## To Reviewers
<!-- 리뷰어에게 남기는 참고사항을 적어주세요 -->

코드 베이스 전체에서 변경하지 못했습니다. totalAttendeesCount가 같이 내려오지 않아 백엔드 요청 후 전체 마이그레이션 예정입니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 행사 정보 조회 데이터 처리 로직 최적화로 안정성 개선

<!-- end of auto-generated comment: release notes by coderabbit.ai -->