### PR TITLE
fix: 추가된 멤버가 중복해서 보이는 문제 해결

### DIFF
--- a/src/hooks/queries/useGetSearchMemberListQuery.ts
+++ b/src/hooks/queries/useGetSearchMemberListQuery.ts
@@ -11,6 +11,7 @@ export const useGetSearchMemberListQuery = (
     queryKey: [QueryKey.searchMemberList, eventId, name],
     queryFn: () => eventApi.getSearchMemberList(eventId, name),
     enabled: enabled && name.trim() !== "",
-    staleTime: 1000 * 60, // 1분
+    staleTime: 0,
+    gcTime: 0,
   });
 };

--- a/src/pages/AfterPartyAttendancePage.tsx
+++ b/src/pages/AfterPartyAttendancePage.tsx
@@ -46,9 +46,7 @@ export default function AfterPartyAttendancePage() {
   );
 
   useEffect(() => {
-    if (eventParticipantList && !isEditMode) {
-      setSelectedIds(initialSelectedIds);
-    }
+    setSelectedIds(initialSelectedIds);
   }, [eventParticipantList, initialSelectedIds, isEditMode]);
 
   const mutation = usePutAfterPartyAttendanceMutation();


### PR DESCRIPTION
## Describe your changes

**쿼리 캐싱 동작 개선**
- `useGetSearchMemberListQuery`의 `staleTime`과 `gcTime`을 모두 `0`으로 설정
- 회원 검색 목록 데이터가 항상 신선하게 조회되도록 보장
- 사용 후 즉시 가비지 컬렉션되어 메모리 효율성 향상

**출석 페이지 로직 단순화**
- `AfterPartyAttendancePage`에서 선택된 참가자 ID 설정 시 `isEditMode` 조건부 체크 제거
- 관련 업데이트 발생 시 항상 `setSelectedIds(initialSelectedIds)` 호출하도록 로직 통일
- `useEffect` 단순화로 코드 가독성 및 유지보수성 향상

<br/>

## To Reviewers
- 출석 페이지에서 편집 모드 여부와 관계없이 ID 설정이 정상적으로 동작하는지 테스트해주세요
- 기존 조건부 로직 제거로 인한 사이드 이펙트가 없는지 검토 부탁드립니다

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **버그 수정**
  * 검색 멤버 목록이 항상 최신 상태를 유지하도록 개선되었습니다.
  * 이벤트 참석자 선택 상태가 더욱 안정적으로 동기화되도록 수정되었습니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->