### PR TITLE
[Fix] 행사/뒤풀이 인원 제한 관련 버그 수정

### DIFF
--- a/src/components/EditEvent/EventForm.tsx
+++ b/src/components/EditEvent/EventForm.tsx
@@ -236,9 +236,10 @@ export const EventForm = ({
       );
 
       // 초기 상태 업데이트 (formValue가 변경될 때만)
-      setInitialState(() => ({
-        formValue: formValue,
-      }));
+      if (initialState.formValue === null)
+        setInitialState(() => ({
+          formValue: formValue,
+        }));
     } else {
       const newFormFields = getFormFields(null);
       setFormFields(newFormFields);

--- a/src/components/EditEvent/EventForm.tsx
+++ b/src/components/EditEvent/EventForm.tsx
@@ -2,6 +2,7 @@ import { useUpdateEventFormMutation } from "@/hooks/mutations/useUpdateEventForm
 import { EventType, UpdateEventFormRequest } from "@/types/dtos/event";
 import { useEffect, useState } from "react";
 import { Link as LinkIcon } from "wowds-icons";
+import { color } from "wowds-tokens";
 import Button from "wowds-ui/Button";
 import { Flex } from "../@common/Flex";
 import { Space } from "../@common/Space";
@@ -302,6 +303,7 @@ export const EventForm = ({
           icon={<LinkIcon stroke="primary" />}
           onClick={handleCopyUrl}
           disabled={!eventId}
+          style={{ backgroundColor: color.blueDisabled }}
         >
           {copied ? "복사 완료!" : "URL 복사하기"}
         </Button>

--- a/src/components/EditEvent/EventInformation.tsx
+++ b/src/components/EditEvent/EventInformation.tsx
@@ -153,7 +153,6 @@ export const EventInformation = ({
 
   useEffect(() => {
     if (formValue) {
-      console.log(formValue);
       // setFormValues는 제거 - 부모에서 이미 관리하고 있음
       setSelectedRange({
         from: parseISO(formValue.applicationPeriod?.startDate),
@@ -219,11 +218,6 @@ export const EventInformation = ({
       });
     }
   }, [formValue, eventId]);
-
-  useEffect(() => {
-    console.log("뒤풀이 인원 가능?", afterPartyLimitEnabled);
-    console.log("뒤풀이 인원 몇명?", afterPartyMaxCount);
-  }, [afterPartyLimitEnabled, afterPartyMaxCount]);
 
   const handleDescriptionChange = (value: string) => {
     setDescription(value);

--- a/src/components/EditEvent/EventInformation.tsx
+++ b/src/components/EditEvent/EventInformation.tsx
@@ -167,7 +167,11 @@ export const EventInformation = ({
       setAfterPartyMaxCount(formValue.afterPartyMaxApplicantCount?.toString() || "");
       setRegularRoleOnlyStatus(formValue.regularRoleOnlyStatus);
       setMainEventLimitEnabled(eventId ? (formValue.mainEventMaxApplicantCount || 0) > 0 : true);
-      setAfterPartyLimitEnabled(formValue.afterPartyStatus === "DISABLED" ? false : true);
+      setAfterPartyLimitEnabled(
+        formValue.afterPartyStatus === "DISABLED"
+          ? false
+          : (formValue.afterPartyMaxApplicantCount || 0) > 0,
+      );
 
       // 초기 상태 업데이트 (formValue가 변경될 때만)
       setInitialState({
@@ -183,7 +187,10 @@ export const EventInformation = ({
         mainEventMaxCount: formValue.mainEventMaxApplicantCount?.toString() || "",
         afterPartyMaxCount: formValue.afterPartyMaxApplicantCount?.toString() || "",
         mainEventLimitEnabled: eventId ? (formValue.mainEventMaxApplicantCount || 0) > 0 : true,
-        afterPartyLimitEnabled: formValue.afterPartyStatus === "DISABLED" ? false : true,
+        afterPartyLimitEnabled:
+          formValue.afterPartyStatus === "DISABLED"
+            ? false
+            : (formValue.afterPartyMaxApplicantCount || 0) > 0,
       });
     } else {
       setSelectedRange(undefined);
@@ -212,6 +219,11 @@ export const EventInformation = ({
       });
     }
   }, [formValue, eventId]);
+
+  useEffect(() => {
+    console.log("뒤풀이 인원 가능?", afterPartyLimitEnabled);
+    console.log("뒤풀이 인원 몇명?", afterPartyMaxCount);
+  }, [afterPartyLimitEnabled, afterPartyMaxCount]);
 
   const handleDescriptionChange = (value: string) => {
     setDescription(value);
@@ -255,7 +267,9 @@ export const EventInformation = ({
       afterPartyMaxApplicantCount:
         formValue?.afterPartyStatus === "DISABLED"
           ? null
-          : formValue?.afterPartyMaxApplicantCount || null,
+          : afterPartyLimitEnabled
+            ? parseInt(afterPartyMaxCount) || 0
+            : null,
       mainEventMaxApplicantCount: mainEventLimitEnabled ? parseInt(mainEventMaxCount) || 0 : null,
     };
 

--- a/src/components/EditEvent/EventInformation.tsx
+++ b/src/components/EditEvent/EventInformation.tsx
@@ -553,7 +553,6 @@ export const EventInformation = ({
                     onChange={handleMainEventMaxCountChange}
                     variant="outlined"
                     fullWidth
-                    type="number"
                     style={{ backgroundColor: "white" }}
                     inputProps={{
                       min: totalAttendeesCount > 0 ? totalAttendeesCount : 1,
@@ -601,7 +600,6 @@ export const EventInformation = ({
                         onChange={handleAfterPartyMaxCountChange}
                         variant="outlined"
                         fullWidth
-                        type="number"
                         style={{ backgroundColor: "white" }}
                         inputProps={{
                           min: totalAttendeesCount > 0 ? totalAttendeesCount : 1,


### PR DESCRIPTION
## Describe your changes
### 값 입력 시 한글 자음, 모음이 입력되던 버그 수정 (QA 사항)
 - TextField의 type="number" 속성 제거를 통해 해결

### 뒤풀이 인원 제한 값 변경이 반영되지 않던 버그 수정
 - 뒤풀이 인원 제한 관련 일부 로직 수정

### EventForm 컴포넌트에서 변경사항이 제대로 비교되지 않던 버그 수정
 - formValue가 변경될 때마다 setInitialState가 실행되는 로직을 수정 (이전 값이 null이었거나 저장 버튼 클릭 시 실행)

url 복사하기 버튼 색상 수정 (QA 사항)

## To Reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **Bug Fixes**
  * 이벤트 편집 폼에서 초기 값이 의도치 않게 덮어써지는 문제 해결
  * 애프터 파티 제한 설정 로직 개선으로 정확한 상태 반영

* **Style**
  * 버튼 비활성화 상태의 시각적 피드백 개선

* **Chores**
  * 코드 정리 및 숫자 입력 검증 방식 개선

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->