### PR TITLE
[Fix] 학기 정보, 모집 회차 마감일 시간 수정

### DIFF
--- a/src/components/Recruitment/CreateRecruitmentInfoModal.tsx
+++ b/src/components/Recruitment/CreateRecruitmentInfoModal.tsx
@@ -1,17 +1,17 @@
-import { ChangeEvent, useState } from "react";
-import styled from "@emotion/styled";
-import { Modal, Typography, Box, Button, TextField } from "@mui/material";
-import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
-import { DatePicker } from "@mui/x-date-pickers/DatePicker";
-import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider/LocalizationProvider";
-import { useQueryClient } from "@tanstack/react-query";
-import { Dayjs } from "dayjs";
-import { toast } from "react-toastify";
 import WarningIcon from "@/assets/warning.svg?react";
 import { QueryKey } from "@/constants/queryKey";
 import useCreateRecruitmentMutation from "@/hooks/mutations/useCreateRecruitmentMutation";
 import { RecruitmentModalInfoType } from "@/types/entities/recruitment";
 import { toKSTISOString } from "@/utils/validation/formatDate";
+import styled from "@emotion/styled";
+import { Box, Button, Modal, TextField, Typography } from "@mui/material";
+import { AdapterDayjs } from "@mui/x-date-pickers/AdapterDayjs";
+import { DatePicker } from "@mui/x-date-pickers/DatePicker";
+import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider/LocalizationProvider";
+import { useQueryClient } from "@tanstack/react-query";
+import { Dayjs } from "dayjs";
+import { ChangeEvent, useState } from "react";
+import { toast } from "react-toastify";
 
 type CreateRecruitmentInfoModalPropsType = {
   open: boolean;
@@ -72,7 +72,7 @@ export default function CreateRecruitmentInfoModal({
     mutate(
       {
         semesterStartDate: toKSTISOString(semesterStartDate.toDate()),
-        semesterEndDate: toKSTISOString(semesterEndDate.toDate()),
+        semesterEndDate: toKSTISOString(semesterEndDate.endOf("day").toDate()),
         academicYear,
         semesterType: semester === "1" ? "FIRST" : "SECOND",
         fee,

--- a/src/components/RecruitmentRound/RecruitmentRoundInfoModal.tsx
+++ b/src/components/RecruitmentRound/RecruitmentRoundInfoModal.tsx
@@ -1,4 +1,13 @@
-import { ChangeEvent, useEffect, useState } from "react";
+import { QueryKey } from "@/constants/queryKey";
+import useCreateRecruitmentRoundMutation from "@/hooks/mutations/useCreateRecruitmentRoundMutation";
+import useEditRecruitmentRoundMutation, {
+  EditRecruitmentRoundMutationArgumentType,
+} from "@/hooks/mutations/useEditRecruitmentRoundMutation";
+import {
+  FilteredRecruitmentRoundInfoType,
+  RecruitmentRoundModalInfoType,
+} from "@/types/entities/recruitment";
+import { toKSTISOString } from "@/utils/validation/formatDate";
 import {
   Box,
   Button,
@@ -15,17 +24,8 @@ import { DatePicker } from "@mui/x-date-pickers/DatePicker";
 import { LocalizationProvider } from "@mui/x-date-pickers/LocalizationProvider/LocalizationProvider";
 import { useQueryClient } from "@tanstack/react-query";
 import dayjs, { Dayjs } from "dayjs";
+import { ChangeEvent, useEffect, useState } from "react";
 import { toast } from "react-toastify";
-import { QueryKey } from "@/constants/queryKey";
-import useCreateRecruitmentRoundMutation from "@/hooks/mutations/useCreateRecruitmentRoundMutation";
-import useEditRecruitmentRoundMutation, {
-  EditRecruitmentRoundMutationArgumentType,
-} from "@/hooks/mutations/useEditRecruitmentRoundMutation";
-import {
-  FilteredRecruitmentRoundInfoType,
-  RecruitmentRoundModalInfoType,
-} from "@/types/entities/recruitment";
-import { toKSTISOString } from "@/utils/validation/formatDate";
 
 export type RecruitmentRoundInfoModalPropsType = {
   open: boolean;
@@ -87,11 +87,9 @@ export default function RecruitmentRoundInfoModal({
       return;
     }
 
-    const adjustedDate = name === "endDate" ? newDate.endOf("day") : newDate;
-
     setRoundModalInfo(prevModalInfo => ({
       ...prevModalInfo,
-      [name]: adjustedDate,
+      [name]: newDate,
     }));
   };
 
@@ -108,7 +106,7 @@ export default function RecruitmentRoundInfoModal({
       semesterType: semester === "1" ? "FIRST" : "SECOND",
       name,
       startDate: toKSTISOString(startDate!.toDate()),
-      endDate: toKSTISOString(endDate!.toDate()),
+      endDate: toKSTISOString(endDate!.endOf("day").toDate()),
       roundType: roundType === "1차" ? "FIRST" : roundType === "2차" ? "SECOND" : "THIRD",
     };
 


### PR DESCRIPTION
## Describe your changes
학기 정보의 semesterEndDate, 모집 회차의 endDate에 endOf("day")를 통해 마감 시간을 날짜의 끝으로 설정했습니다.

## To Reviewers


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## 릴리스 노트

* **버그 수정**
  * 채용 관련 모달에서 종료 날짜 처리 개선 - 종료 날짜가 이제 하루의 끝(자정)으로 올바르게 설정됩니다.
  * 날짜 선택 시 종료 날짜 계산 로직 정규화로 일관성 있는 날짜 처리 구현.

* **개선 사항**
  * 채용 정보 입력 시 날짜 처리 흐름 최적화.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->