### PR TITLE
[Refactor] 행사 조회, 검색 api 통합

### DIFF
--- a/src/apis/eventApi.ts
+++ b/src/apis/eventApi.ts
@@ -4,6 +4,7 @@ import { AfterPartyData } from "@/components/EditEvent/mockData/afterPartyMockDa
 import {
   AfterPartyAttendanceListResponse,
   CreateEventRequest,
+  EventContent,
   EventParticipantsResponse,
   EventResponse,
   EventType,
@@ -31,8 +32,8 @@ export const eventApi = {
     const response = await apiClient.put(`/admin/events/${eventId}/form-info`, eventData);
     return response.data;
   },
-  getSpecificEvent: async (eventId: number): Promise<EventType> => {
-    const response = await apiClient.get<EventType>(`/common/events/${eventId}`);
+  getSpecificEvent: async (eventId: number): Promise<EventContent> => {
+    const response = await apiClient.get<EventContent>(`/admin/events/${eventId}`);
     return response.data;
   },
   getEventList: async (

--- a/src/apis/eventApi.ts
+++ b/src/apis/eventApi.ts
@@ -35,31 +35,20 @@ export const eventApi = {
     const response = await apiClient.get<EventType>(`/common/events/${eventId}`);
     return response.data;
   },
-  getSearchEventList: async (
+  getEventList: async (
     page: number = 1,
     size: number = 20,
     sort: string = "",
-    name: string,
+    name: string = "",
   ): Promise<EventResponse> => {
     const response = await apiClient.get<EventResponse>(`/admin/events/search`, {
       params: {
-        name,
+        ...(name && { name }),
         page,
         size,
         sort: sort || undefined,
       },
     });
-    return response.data;
-  },
-  getEventList: async (
-    page: number = 1,
-    size: number = 20,
-    sort: string = "",
-  ): Promise<EventResponse> => {
-    const response = await apiClient.get<EventResponse>(`/admin/events`, {
-      params: { page, size, sort },
-    });
-
     return response.data;
   },
   getParticipants: async (

--- a/src/components/EditEvent/AfterPartyManagement.tsx
+++ b/src/components/EditEvent/AfterPartyManagement.tsx
@@ -18,7 +18,11 @@ import { useUpdateAfterPartyStatusMutation } from "@/hooks/mutations/useUpdateAf
 import { useUpdateAllAfterPartyStatusMutation } from "@/hooks/mutations/useUpdateAllAfterPartyStatusMutation";
 import { useGetAfterPartyApplicants } from "@/hooks/queries/useGetAfterPartyApplicants";
 import { isDigitStart, onlyDigits, isEnglishStart, isKoreanStart } from "@/utils/searchQuery";
-export const AfterPartyManagement = () => {
+export const AfterPartyManagement = ({
+  afterPartyEnabled,
+}: {
+  afterPartyEnabled: boolean;
+}) => {
   const { eventId } = useParams<{ eventId: string }>();
   const id = Number(eventId);
 
@@ -33,7 +37,7 @@ export const AfterPartyManagement = () => {
     data: apiData,
     isLoading,
     error,
-  } = useGetAfterPartyApplicants(id, currentPage, pageSize, sortKey);
+  } = useGetAfterPartyApplicants(id, currentPage, pageSize, sortKey, afterPartyEnabled);
 
   // 로컬 상태 업데이트를 위한 onSuccess 콜백
   const handleLocalStateUpdate = (
@@ -291,7 +295,7 @@ export const AfterPartyManagement = () => {
             {apiData?.applicants?.totalElements || 0}명
           </Text>
         </Text>
-        <Button variant="solid" size="sm" onClick={() => setModalOpen(true)}>
+        <Button variant="solid" size="sm" onClick={() => setModalOpen(true)} disabled={!afterPartyEnabled}>
           뒤풀이 인원 확인
         </Button>
       </Flex>

--- a/src/hooks/queries/useGetAfterPartyApplicants.ts
+++ b/src/hooks/queries/useGetAfterPartyApplicants.ts
@@ -8,11 +8,12 @@ export const useGetAfterPartyApplicants = (
   page: number = 0,
   size: number = 20,
   sort: string = "",
+  afterPartyEnabled: boolean = true,
 ) => {
   return useQuery<AfterPartyData>({
     queryKey: ["afterPartyApplicants", eventId, page, size, sort],
     queryFn: () => eventApi.getAfterPartyApplicants(eventId, page, size, sort),
     staleTime: 60_000,
-    enabled: !!eventId,
+    enabled: !!eventId && afterPartyEnabled,
   });
 };

--- a/src/hooks/queries/useGetEvent.ts
+++ b/src/hooks/queries/useGetEvent.ts
@@ -9,12 +9,10 @@ export const useGetEvent = (eventId: number | null) => {
         return null;
       }
 
-      // 전체 이벤트 목록에서 특정 이벤트 찾기
-      const eventListResponse = await eventApi.getEventList(0, 100);
-      const event = eventListResponse.content.find(c => c.event.eventId === eventId);
+      const eventContent = await eventApi.getSpecificEvent(eventId);
       return {
-        eventData: event?.event || null,
-        currentApplicantCount: event?.mainEventCurrentApplicantCount,
+        eventData: eventContent.event,
+        currentApplicantCount: eventContent.mainEventCurrentApplicantCount,
       };
     },
     enabled: eventId !== null && eventId > 0,

--- a/src/hooks/queries/useGetEventList.ts
+++ b/src/hooks/queries/useGetEventList.ts
@@ -1,10 +1,10 @@
-// hooks/useEventList.ts
+// hooks/queries/useGetEventList.ts
 import { eventApi } from "@/apis/eventApi";
 import { QueryKey } from "@/constants/queryKey";
 import { EventResponse } from "@/types/dtos/event";
 import { keepPreviousData, useQuery } from "@tanstack/react-query";
 
-export const useEventList = (
+export const useGetEventList = (
   page: number = 1,
   size: number = 20,
   sort: string = "",

--- a/src/hooks/queries/useGetEventQueries.ts
+++ b/src/hooks/queries/useGetEventQueries.ts
@@ -12,10 +12,7 @@ export const useEventList = (
 ) => {
   return useQuery<EventResponse>({
     queryKey: [QueryKey.eventList, page, size, sort, searchQuery],
-    queryFn: () =>
-      searchQuery.length === 0
-        ? eventApi.getEventList(page, size, sort)
-        : eventApi.getSearchEventList(page, size, sort, searchQuery),
+    queryFn: () => eventApi.getEventList(page, size, sort, searchQuery),
     placeholderData: keepPreviousData, // 페이지 전환 시 데이터 fetching 전까지 기존 데이터 유지
     staleTime: 1000 * 600,
   });

--- a/src/pages/AfterPartyAttendancePage.tsx
+++ b/src/pages/AfterPartyAttendancePage.tsx
@@ -140,7 +140,7 @@ export default function AfterPartyAttendancePage() {
     <MobileLayout
       header={
         <AfterPartyAttendanceHeader
-          headerTitle={eventData.data?.name || "뒤풀이 참석자 관리"}
+          headerTitle={eventData.data?.event.name || "뒤풀이 참석자 관리"}
           onEditClick={() => {
             if (isEditMode) {
               handleSave();

--- a/src/pages/EditEventPage.tsx
+++ b/src/pages/EditEventPage.tsx
@@ -90,7 +90,7 @@ export const EditEventPage = () => {
             <ApplyMember title={formValues?.name || ""} />
           </TabContent>
           <TabContent isActive={activeTab === "tab3"}>
-            <AfterPartyManagement />
+            <AfterPartyManagement afterPartyEnabled={formValues?.afterPartyStatus === "ENABLED"} />
           </TabContent>
         </>
       )}

--- a/src/pages/EventsHomePage.tsx
+++ b/src/pages/EventsHomePage.tsx
@@ -9,7 +9,7 @@ import SearchBar from "wowds-ui/SearchBar";
 import { Space } from "@/components/@common/Space";
 import { OfflineEventCard } from "@/components/OfflineEvent/EventBox";
 import { useDebounce } from "@/hooks/common/useDebounce";
-import { useEventList } from "@/hooks/queries/useGetEventQueries";
+import { useGetEventList } from "@/hooks/queries/useGetEventList";
 import RoutePath from "@/routes/routePath";
 
 export const EventsHomePage = () => {
@@ -21,7 +21,7 @@ export const EventsHomePage = () => {
   // 검색어 debounce 적용 (300ms 지연)
   const debouncedSearchQuery = useDebounce(searchQuery, 300);
 
-  const { data } = useEventList(currentPage, pageSize, "startAt,desc", debouncedSearchQuery); // useEventList는 1부터 시작
+  const { data } = useGetEventList(currentPage, pageSize, "startAt,desc", debouncedSearchQuery);
   const eventContent = data?.content ?? [];
 
   // 페이지 변경 핸들러


### PR DESCRIPTION
## Describe your changes
### useEventList
- `eventApi.getEventList` (전체 조회)와 `eventApi.getSearchEventList` (검색)를 `getEventList` 하나로 통합
- `useEventList` 훅의 분기 로직 제거
- `useEventList` → `useGetEventList`로 이름 변경

### useGetEvent
- 행사 상세 조회 API 엔드포인트를 `/common/events/{eventId}` → `/admin/events/{eventId}`로 변경
- `useGetEvent` 훅에서 전체 목록 조회 후 find하던 로직을 `getSpecificEvent` 직접 호출로 개선

### 뒤풀이 관련 에러
- 뒤풀이가 비활성화된 행사에서 뒤풀이 참여자 API 호출 시 400 에러 발생하던 문제 수정
- 뒤풀이 비활성화 시 "뒤풀이 인원 확인" 버튼도 disabled 처리

## To Reviewers
- 기존 `GET /admin/events` (전체 조회) API가 백엔드에서 삭제되고 `GET /admin/events/search`로 통합되었습니다. 검색어가 없으면 전체 목록을 반환합니다.
- 행사 상세 조회 API도 `GET /common/events/{eventId}` → `GET /admin/events/{eventId}`로 변경되었고, 응답에 `mainEventCurrentApplicantCount`, `eventStatus` 등이 포함되어 별도로 목록을 조회할 필요가 없어졌습니다.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## 릴리스 노트

* **개선사항**
  * 개별 이벤트 조회 방식 개선으로 상세 정보 로딩 성능 향상
  * 이벤트 목록 검색 동작 개선 및 검색어 처리 일관화

* **버그 수정**
  * 뒤풀이 참석자 관리 페이지의 헤더 제목 표시 문제 해결

* **리팩토링**
  * 이벤트 관련 데이터 조회 흐름 및 훅/엔드포인트 정리

* **사용성**
  * 뒤풀이 기능 비활성 시 참석자 확인 버튼을 비활성화하여 불필요한 동작 방지
<!-- end of auto-generated comment: release notes by coderabbit.ai -->